### PR TITLE
Add signing and verification for arbitrary messages.

### DIFF
--- a/src/main/java/dev/jlibra/mnemonic/ExtendedPrivKey.java
+++ b/src/main/java/dev/jlibra/mnemonic/ExtendedPrivKey.java
@@ -1,6 +1,7 @@
 package dev.jlibra.mnemonic;
 
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.bouncycastle.crypto.signers.Ed25519Signer;
 import org.bouncycastle.jcajce.provider.digest.SHA3;
 import org.bouncycastle.util.encoders.Hex;
@@ -32,22 +33,50 @@ public class ExtendedPrivKey {
         return Hex.toHexString(digest256.digest());
     }
 
-    public byte[] sign(RawTransaction rawTransaction) {
-        SHA3.DigestSHA3 digestSHA3 = new SHA3.Digest256();
-        byte[] saltDigest = digestSHA3.digest("RawTransaction@@$$LIBRA$$@@".getBytes());
-        byte[] transactionBytes = rawTransaction.toByteArray();
-        byte[] message = ByteBuffer.allocate(saltDigest.length + transactionBytes.length)
-                .put(saltDigest)
-                .put(transactionBytes)
-                .array();
+    public byte[] signTransaction(RawTransaction rawTransaction) {
+        return sign("RawTransaction@@$$LIBRA$$@@", rawTransaction.toByteArray());
+    }
 
+    public byte[] signMessage(byte[] rawMessage) {
+        return sign("Message@@$$LIBRA$$@@", rawMessage);
+    }
+
+    private byte[] sign(String prefix, byte[] bytesToSign) {
+        SHA3.DigestSHA3 digestSHA3 = new SHA3.Digest256();
+        byte[] message = prepareMessage(prefix, bytesToSign);
         try {
             Ed25519Signer signer = new Ed25519Signer();
             signer.init(true, new Ed25519PrivateKeyParameters(privateKey.getData(), 0));
-            signer.update(digestSHA3.digest(message), 0, message.length);
+            signer.update(digestSHA3.digest(message), 0, 32);
             return signer.generateSignature();
         } catch (Exception e) {
-            throw new RuntimeException("Signing the transaction failed", e);
+            throw new RuntimeException("Signing the payload failed", e);
+        }
+    }
+
+    private byte[] prepareMessage(String prefix, byte[] bytesToSign) {
+        SHA3.DigestSHA3 digestSHA3 = new SHA3.Digest256();
+        byte[] saltDigest = digestSHA3.digest(prefix.getBytes());
+        return ByteBuffer.allocate(saltDigest.length + bytesToSign.length)
+                .put(saltDigest)
+                .put(bytesToSign)
+                .array();
+    }
+
+    public boolean verifyMessage(byte[] bytesMessage, byte[] signature) {
+        return verify("Message@@$$LIBRA$$@@", bytesMessage, signature);
+    }
+
+    private boolean verify(String prefix, byte[] bytesToSign, byte[] signedBytes) {
+        SHA3.DigestSHA3 digestSHA3 = new SHA3.Digest256();
+        byte[] message = prepareMessage(prefix, bytesToSign);
+        try {
+            Ed25519Signer signer = new Ed25519Signer();
+            signer.init(false, new Ed25519PublicKeyParameters(publicKey.getData(), 0));
+            signer.update(digestSHA3.digest(message), 0, 32);
+            return signer.verifySignature(signedBytes);
+        } catch (Exception e) {
+            throw new RuntimeException("Verification of payload failed", e);
         }
     }
 }

--- a/src/test/java/dev/jlibra/mnemonic/ExtendedPrivKeyTest.java
+++ b/src/test/java/dev/jlibra/mnemonic/ExtendedPrivKeyTest.java
@@ -5,12 +5,19 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.nio.charset.Charset;
 import java.security.Security;
 
 import static dev.jlibra.mnemonic.LibraKeyFactoryTest.TEST_MNEMONIC;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class ExtendedPrivKeyTest {
+
+    private static final byte[] TEST_MESSAGE_UTF8 =
+            "Ḽơᶉëᶆ ȋṕšᶙṁ ḍỡḽǭᵳ ʂǐť ӓṁệẗ, ĉṓɲṩḙċťᶒțûɾ ấɖḯƥĭṩčįɳġ ḝłįʈ, șếᶑ ᶁⱺ ẽḭŭŝḿꝋď ṫĕᶆᶈṓɍ ỉñḉīḑȋᵭṵńť ṷŧ ḹẩḇőꝛế éȶ đꝍꞎôꝛȇ ᵯáꞡᶇā ąⱡîɋṹẵ.".getBytes(Charset.forName("UTF-8"));
+    private static final byte[] TEST_MESSAGE_UTF8_DIFF =
+            "Ḽơᶉëᶆ ȋṕšᶙṁ ḍỡḽǭᵳ ʂǐť ӓṁệẗ, ĉṓɲṩḙċťᶒțûɾ ấɖḯƥĭṩčįɳġ ḝłįʈ, șếᶑ ᶁⱺ ẽḭŭŝḿꝋď ṫĕᶆᶈṓɍ ỉñḉīḑȋᵭṵńť ṷŧ ḹẩḇőꝛế éȶ đꝍꞎôꝛȇ ᵯáꞡᶇā ąⱡîɋṹẵ,".getBytes(Charset.forName("UTF-8"));
+
 
     @BeforeClass
     public static void setUpClass() {
@@ -25,12 +32,7 @@ public class ExtendedPrivKeyTest {
     @Test
     @Ignore("todo")
     public void getPublic() {
-        Mnemonic mnemonic = Mnemonic.fromString(TEST_MNEMONIC);
-        Seed seed = new Seed(mnemonic, "LIBRA");
-        LibraKeyFactory libraKeyFactory = new LibraKeyFactory(seed);
-
-        // Check child_0 key derivation.
-        ExtendedPrivKey childPrivate0 = libraKeyFactory.privateChild(new ChildNumber(0));
+        ExtendedPrivKey childPrivate0 = createExtendedPrivKey();
 
         assertEquals(
                 "daae450c405afcad7fef66d3a7f7fae686247cf3064d7151d9a4a76ae0cace9a",
@@ -41,5 +43,30 @@ public class ExtendedPrivKeyTest {
     @Test
     @Ignore("todo")
     public void sign() {
+
     }
+
+    @Test
+    public void signAndVerifyMessageSuccessful() {
+        ExtendedPrivKey childPrivate0 = createExtendedPrivKey();
+        byte[] signedMessage = childPrivate0.signMessage(TEST_MESSAGE_UTF8);
+        boolean isMessageSignedWithPrivateKey = childPrivate0.verifyMessage(TEST_MESSAGE_UTF8, signedMessage);
+        assertTrue("signed message cannot be verified for key " + childPrivate0.publicKey.toString(), isMessageSignedWithPrivateKey);
+    }
+
+    @Test
+    public void signAndVerifyMessageNotSuccessful() {
+        ExtendedPrivKey childPrivate0 = createExtendedPrivKey();
+        byte[] signedMessage = childPrivate0.signMessage(TEST_MESSAGE_UTF8);
+        boolean isMessageSignedWithPrivateKey = childPrivate0.verifyMessage(TEST_MESSAGE_UTF8_DIFF, signedMessage);
+        assertFalse("signed message cannot be verified for key " + childPrivate0.publicKey.toString(), isMessageSignedWithPrivateKey);
+    }
+
+    private ExtendedPrivKey createExtendedPrivKey() {
+        Mnemonic mnemonic = Mnemonic.fromString(TEST_MNEMONIC);
+        Seed seed = new Seed(mnemonic, "LIBRA");
+        LibraKeyFactory libraKeyFactory = new LibraKeyFactory(seed);
+        return libraKeyFactory.privateChild(new ChildNumber(0));
+    }
+
 }


### PR DESCRIPTION
- Added signing and verification for arbitrary messages and not only transactions
- Feature helps users to check if a message was signed by a private key
- This is just a first step, a generic "ecrecovery" function is still missing which allows for checking a signature against an address