### PR TITLE
Fixing multiple issues in preparation for issue 27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target
 .project
 .idea
+*.iml

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/GrpcMapper.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/GrpcMapper.java
@@ -1,28 +1,12 @@
 package dev.jlibra.admissioncontrol;
 
-import static java.util.stream.Collectors.toList;
-
-import java.io.IOException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import com.google.protobuf.ByteString;
-
 import admission_control.AdmissionControlOuterClass.SubmitTransactionRequest;
+import com.google.protobuf.ByteString;
 import dev.jlibra.AccountState;
 import dev.jlibra.KeyUtils;
 import dev.jlibra.LibraHelper;
-import dev.jlibra.admissioncontrol.query.GetAccountState;
-import dev.jlibra.admissioncontrol.query.GetAccountTransactionBySequenceNumber;
-import dev.jlibra.admissioncontrol.query.ImmutableUpdateToLatestLedgerResult;
-import dev.jlibra.admissioncontrol.query.SignedTransactionWithProof;
-import dev.jlibra.admissioncontrol.query.UpdateToLatestLedgerResult;
+import dev.jlibra.admissioncontrol.query.*;
 import dev.jlibra.admissioncontrol.transaction.Transaction;
-import dev.jlibra.admissioncontrol.transaction.TransactionArgument.Type;
 import types.GetWithProof.GetAccountStateRequest;
 import types.GetWithProof.GetAccountTransactionBySequenceNumberRequest;
 import types.GetWithProof.RequestItem;
@@ -31,30 +15,27 @@ import types.Transaction.Program;
 import types.Transaction.RawTransaction;
 import types.Transaction.SignedTransaction;
 import types.Transaction.TransactionArgument;
-import types.Transaction.TransactionArgument.ArgType;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 public class GrpcMapper {
-    private static Map<Type, ArgType> jlibraArgumentTypeToGrpcArgumentType;
-
-    static {
-        jlibraArgumentTypeToGrpcArgumentType = new HashMap<>();
-        jlibraArgumentTypeToGrpcArgumentType.put(Type.ADDRESS, ArgType.ADDRESS);
-        jlibraArgumentTypeToGrpcArgumentType.put(Type.U64, ArgType.U64);
-    }
 
     public static SubmitTransactionRequest toSubmitTransactionRequest(PublicKey publicKey, PrivateKey privateKey,
             Transaction transaction) {
+
         List<TransactionArgument> transactionArguments = transaction.getProgram().getArguments().stream()
-                .map(txArgument -> TransactionArgument.newBuilder()
-                        .setType(jlibraArgumentTypeToGrpcArgumentType.get(txArgument.type()))
-                        .setData(ByteString.copyFrom(txArgument.toByteArray()))
-                        .build())
+                .map(dev.jlibra.admissioncontrol.transaction.TransactionArgument::toGrpcTransactionArgument)
                 .collect(toList());
 
         Program program = Program.newBuilder()
                 .addAllArguments(transactionArguments)
-                .setCode(readCodeFromStream(transaction))
-                .addAllModules(new ArrayList<ByteString>())
+                .setCode(transaction.getProgram().getCode())
+                .addAllModules(new ArrayList<>())
                 .build();
 
         RawTransaction rawTransaction = RawTransaction.newBuilder()
@@ -77,14 +58,6 @@ public class GrpcMapper {
                 .build();
 
         return submitTransactionRequest;
-    }
-
-    private static ByteString readCodeFromStream(Transaction transaction) {
-        try {
-            return ByteString.readFrom(transaction.getProgram().getCode());
-        } catch (IOException e) {
-            throw new RuntimeException("Could not read move code from input stream", e);
-        }
     }
 
     public static List<RequestItem> accountStateQueriesToRequestItems(List<GetAccountState> accountStateQueries) {

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/AddressArgument.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/AddressArgument.java
@@ -1,5 +1,10 @@
 package dev.jlibra.admissioncontrol.transaction;
 
+import com.google.protobuf.ByteString;
+import types.Transaction;
+
+import static types.Transaction.TransactionArgument.ArgType.ADDRESS;
+
 public class AddressArgument implements TransactionArgument {
 
     private byte[] address;
@@ -17,5 +22,11 @@ public class AddressArgument implements TransactionArgument {
     public Type type() {
         return Type.ADDRESS;
     }
-
+    @Override
+    public types.Transaction.TransactionArgument toGrpcTransactionArgument() {
+        return Transaction.TransactionArgument.newBuilder()
+                .setType(ADDRESS)
+                .setData(ByteString.copyFrom(toByteArray()))
+                .build();
+    }
 }

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/Program.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/Program.java
@@ -1,14 +1,14 @@
 package dev.jlibra.admissioncontrol.transaction;
 
-import java.io.InputStream;
-import java.util.List;
-
+import com.google.protobuf.ByteString;
 import org.immutables.value.Value;
+
+import java.util.List;
 
 @Value.Immutable
 public interface Program {
 
-    InputStream getCode();
+    ByteString getCode();
 
     List<TransactionArgument> getArguments();
 

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/SubmitTransactionResult.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/SubmitTransactionResult.java
@@ -1,9 +1,9 @@
 package dev.jlibra.admissioncontrol.transaction;
 
-import org.immutables.value.Value;
-
 import admission_control.AdmissionControlOuterClass.AdmissionControlStatus;
-import mempool.MempoolStatus;
+import admission_control.AdmissionControlOuterClass.SubmitTransactionResponse.StatusCase;
+import mempool.MempoolStatus.MempoolAddTransactionStatus;
+import org.immutables.value.Value;
 import types.VmErrors.VMStatus;
 
 @Value.Immutable
@@ -14,8 +14,9 @@ public interface SubmitTransactionResult {
 
     AdmissionControlStatus getAdmissionControlStatus();
 
-    MempoolStatus.MempoolAddTransactionStatus getMempoolStatus();
+    MempoolAddTransactionStatus getMempoolStatus();
 
     VMStatus getVmStatus();
 
+    StatusCase getStatusCase();
 }

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/TransactionArgument.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/TransactionArgument.java
@@ -1,8 +1,10 @@
 package dev.jlibra.admissioncontrol.transaction;
 
+import types.Transaction;
+
 public interface TransactionArgument {
 
-    public enum Type {
+    enum Type {
         U64, ADDRESS
     }
 
@@ -10,4 +12,5 @@ public interface TransactionArgument {
 
     Type type();
 
+    Transaction.TransactionArgument toGrpcTransactionArgument();
 }

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/U64Argument.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/U64Argument.java
@@ -1,8 +1,12 @@
 package dev.jlibra.admissioncontrol.transaction;
 
-import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import com.google.protobuf.ByteString;
+import types.Transaction;
 
 import java.nio.ByteBuffer;
+
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static types.Transaction.TransactionArgument.ArgType.U64;
 
 public class U64Argument implements TransactionArgument {
 
@@ -23,4 +27,11 @@ public class U64Argument implements TransactionArgument {
         return Type.U64;
     }
 
+    @Override
+    public types.Transaction.TransactionArgument toGrpcTransactionArgument() {
+        return Transaction.TransactionArgument.newBuilder()
+                .setType(U64)
+                .setData(ByteString.copyFrom(toByteArray()))
+                .build();
+    }
 }

--- a/jlibra-core/src/main/java/dev/jlibra/mnemonic/Mnemonic.java
+++ b/jlibra-core/src/main/java/dev/jlibra/mnemonic/Mnemonic.java
@@ -10,7 +10,7 @@ import static java.util.Arrays.asList;
 @Immutable
 public class Mnemonic {
 
-    private static final List<String> WORDS = Collections.unmodifiableList(asList(
+    public static final List<String> WORDS = Collections.unmodifiableList(asList(
             "abandon", "ability", "able", "about", "above", "absent", "absorb", "abstract", "absurd",
             "abuse", "access", "accident", "account", "accuse", "achieve", "acid", "acoustic", "acquire",
             "across", "act", "action", "actor", "actress", "actual", "adapt", "add", "addict", "address",

--- a/jlibra-core/src/main/java/dev/jlibra/move/Move.java
+++ b/jlibra-core/src/main/java/dev/jlibra/move/Move.java
@@ -1,11 +1,21 @@
 package dev.jlibra.move;
 
+import com.google.protobuf.ByteString;
+
+import java.io.IOException;
 import java.io.InputStream;
 
 public class Move {
 
-    public static InputStream peerToPeerTransfer() {
-        return Move.class.getResourceAsStream("/move/peer_to_peer_transfer.bin");
-    }
+    public static final ByteString peerToPeerTransfer = peerToPeerTransfer();
 
+    private static ByteString peerToPeerTransfer() {
+        String programBinary = "/move/peer_to_peer_transfer.bin";
+        InputStream p2pTransferStream = Move.class.getResourceAsStream(programBinary);
+        try {
+            return ByteString.readFrom(p2pTransferStream);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not load program binary from " + programBinary);
+        }
+    }
 }

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/GrpcMapperTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/GrpcMapperTest.java
@@ -1,35 +1,27 @@
 package dev.jlibra.admissioncontrol;
 
-import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.emptyIterable;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import admission_control.AdmissionControlOuterClass.SubmitTransactionRequest;
+import com.google.protobuf.ByteString;
+import dev.jlibra.KeyUtils;
+import dev.jlibra.admissioncontrol.query.ImmutableGetAccountState;
+import dev.jlibra.admissioncontrol.query.ImmutableGetAccountTransactionBySequenceNumber;
+import dev.jlibra.admissioncontrol.transaction.*;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import types.GetWithProof.RequestItem;
+import types.Transaction.RawTransaction;
+import types.Transaction.TransactionArgument.ArgType;
 
-import java.io.ByteArrayInputStream;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Security;
 import java.util.List;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.util.encoders.Hex;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import admission_control.AdmissionControlOuterClass.SubmitTransactionRequest;
-import dev.jlibra.KeyUtils;
-import dev.jlibra.admissioncontrol.query.ImmutableGetAccountState;
-import dev.jlibra.admissioncontrol.query.ImmutableGetAccountTransactionBySequenceNumber;
-import dev.jlibra.admissioncontrol.transaction.AddressArgument;
-import dev.jlibra.admissioncontrol.transaction.ImmutableProgram;
-import dev.jlibra.admissioncontrol.transaction.ImmutableTransaction;
-import dev.jlibra.admissioncontrol.transaction.Transaction;
-import dev.jlibra.admissioncontrol.transaction.U64Argument;
-import types.GetWithProof.RequestItem;
-import types.Transaction.RawTransaction;
-import types.Transaction.TransactionArgument.ArgType;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
 
 public class GrpcMapperTest {
 
@@ -50,7 +42,7 @@ public class GrpcMapperTest {
                 .sequenceNumber(1)
                 .program(ImmutableProgram.builder()
                         .addArguments(new U64Argument(1000), new AddressArgument(new byte[] { 2 }))
-                        .code(new ByteArrayInputStream(new byte[] { 1 }))
+                        .code(ByteString.copyFrom(new byte[] { 1 }))
                         .build())
                 .build();
 

--- a/jlibra-core/src/test/java/dev/jlibra/mnemonic/ExtendedPrivKeyTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/mnemonic/ExtendedPrivKeyTest.java
@@ -1,15 +1,26 @@
 package dev.jlibra.mnemonic;
 
+import dev.jlibra.admissioncontrol.transaction.AddressArgument;
+import dev.jlibra.admissioncontrol.transaction.U64Argument;
+import dev.jlibra.move.Move;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
+import types.Transaction;
 
 import java.security.Security;
+import java.util.ArrayList;
+import java.util.List;
 
-import static dev.jlibra.mnemonic.LibraKeyFactoryTest.TEST_MNEMONIC;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+/**
+ * Test data and mnemonic seed generated using libra cli.
+ */
 public class ExtendedPrivKeyTest {
 
     @BeforeClass
@@ -17,29 +28,75 @@ public class ExtendedPrivKeyTest {
         Security.addProvider(new BouncyCastleProvider());
     }
 
-    @Test
-    @Ignore("todo")
-    public void getAddress() {
+    private ExtendedPrivKey childPrivate0;
+
+    @Before
+    public void setUp() {
+        Mnemonic mnemonic = Mnemonic.fromString("aim layer grit goat orchard daring lady work dice lottery tent virus push heavy hello endless inner bread cliff brick swallow general method walnut");
+        Seed seed = new Seed(mnemonic, "LIBRA");
+        LibraKeyFactory libraKeyFactory = new LibraKeyFactory(seed);
+        childPrivate0 = libraKeyFactory.privateChild(new ChildNumber(0));
     }
 
     @Test
-    @Ignore("todo")
-    public void getPublic() {
-        Mnemonic mnemonic = Mnemonic.fromString(TEST_MNEMONIC);
-        Seed seed = new Seed(mnemonic, "LIBRA");
-        LibraKeyFactory libraKeyFactory = new LibraKeyFactory(seed);
-
-        // Check child_0 key derivation.
-        ExtendedPrivKey childPrivate0 = libraKeyFactory.privateChild(new ChildNumber(0));
-
+    public void getAddress() {
         assertEquals(
-                "daae450c405afcad7fef66d3a7f7fae686247cf3064d7151d9a4a76ae0cace9a",
-                childPrivate0.publicKey.toString()
+                "9263e21488ea4742c54de0d961c94743a01a974c6f095d8710f83044f0408ae7",
+                childPrivate0.getAddress()
         );
     }
 
     @Test
-    @Ignore("todo")
+    public void getPublic() {
+        assertEquals(
+                "be10d382d1f3de00c19607f667b5b127da22f42f0a3a4b70eaef690365421511",
+                childPrivate0.publicKey.toString()
+        );
+    }
+
+    /**
+     * From https://github.com/libra/libra/blob/master/client/libra_wallet/src/key_factory.rs:
+     *
+     * "NOTE: In Libra, we do not sign the raw bytes of a transaction, instead we sign the raw
+     *        bytes of the sha3 hash of the raw bytes of a transaction."
+     */
+    @Test
     public void sign() {
+        // Arguments for the peer to peer transaction
+        U64Argument amountArgument = new U64Argument(1_000_000);
+        AddressArgument addressArgument = new AddressArgument(Hex.decode(childPrivate0.getAddress()));
+        List<Transaction.TransactionArgument> transactionArguments = asList(
+                amountArgument.toGrpcTransactionArgument(),
+                addressArgument.toGrpcTransactionArgument()
+        );
+
+        Transaction.Program program = Transaction.Program.newBuilder()
+                .addAllArguments(transactionArguments)
+                .setCode(Move.peerToPeerTransfer)
+                .addAllModules(new ArrayList<>())
+                .build();
+
+        Transaction.RawTransaction rawTransaction = Transaction.RawTransaction.newBuilder()
+                .setSequenceNumber(0)
+                .setMaxGasAmount(6000)
+                .setGasUnitPrice(1)
+                .setExpirationTime(10000)
+                .setProgram(program)
+                .build();
+
+        byte[] signature = childPrivate0.sign(rawTransaction);
+
+        assertEquals(
+                "0a026288ec43a0b44dc73bb386f69b1b0ef1374ec86577c30d5d3e64b57f4020ab219bb7b904c7c34f6f391e7f52568478569f8e11d7284f318bb2c00ddd1b0b",
+                Hex.toHexString(signature)
+        );
+    }
+
+    @Test
+    public void signAndVerifyMessageSuccessful() {
+        byte[] message = "The things I do for love.".getBytes();
+        byte[] signature = childPrivate0.sign(message);
+
+        assertTrue(childPrivate0.verify(signature, message));
     }
 }

--- a/jlibra-core/src/test/java/dev/jlibra/move/MoveTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/move/MoveTest.java
@@ -1,17 +1,17 @@
 package dev.jlibra.move;
 
-import static org.apache.commons.io.IOUtils.toByteArray;
+import com.google.protobuf.ByteString;
+import org.junit.Test;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
-
-import org.junit.Test;
 
 public class MoveTest {
 
     @Test
     public void testPeerToPeerTransfer() throws Exception {
-        assertThat(toByteArray(Move.peerToPeerTransfer()),
-                equalTo(toByteArray(MoveTest.this.getClass().getResourceAsStream("/move/peer_to_peer_transfer.bin"))));
+        assertThat(Move.peerToPeerTransfer,
+                equalTo(ByteString.readFrom(MoveTest.this.getClass().getResourceAsStream("/move/peer_to_peer_transfer.bin"))));
     }
 
 }

--- a/jlibra-examples/src/main/java/dev/jlibra/example/TransferExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/TransferExample.java
@@ -1,24 +1,20 @@
 package dev.jlibra.example;
 
-import static dev.jlibra.KeyUtils.toHexStringLibraAddress;
+import dev.jlibra.KeyUtils;
+import dev.jlibra.admissioncontrol.AdmissionControl;
+import dev.jlibra.admissioncontrol.transaction.*;
+import dev.jlibra.move.Move;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import org.bouncycastle.util.encoders.Hex;
 
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Security;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
-import org.bouncycastle.util.encoders.Hex;
-
-import dev.jlibra.KeyUtils;
-import dev.jlibra.admissioncontrol.AdmissionControl;
-import dev.jlibra.admissioncontrol.transaction.AddressArgument;
-import dev.jlibra.admissioncontrol.transaction.ImmutableProgram;
-import dev.jlibra.admissioncontrol.transaction.ImmutableTransaction;
-import dev.jlibra.admissioncontrol.transaction.SubmitTransactionResult;
-import dev.jlibra.admissioncontrol.transaction.Transaction;
-import dev.jlibra.admissioncontrol.transaction.U64Argument;
-import dev.jlibra.move.Move;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
+import static dev.jlibra.KeyUtils.toHexStringLibraAddress;
 
 public class TransferExample {
 
@@ -52,10 +48,10 @@ public class TransferExample {
                 .sequenceNumber(sequenceNumber)
                 .maxGasAmount(6000)
                 .gasUnitPrice(1)
-                .expirationTime(10000)
+                .expirationTime(Instant.now().plus(1, ChronoUnit.HOURS).getEpochSecond())
                 .program(
                         ImmutableProgram.builder()
-                                .code(Move.peerToPeerTransfer())
+                                .code(Move.peerToPeerTransfer)
                                 .addArguments(addressArgument, amountArgument)
                                 .build())
                 .build();

--- a/jlibra-grpc/src/main/proto/vm_errors.proto
+++ b/jlibra-grpc/src/main/proto/vm_errors.proto
@@ -73,8 +73,8 @@ enum VMValidationStatusCode {
 }
 
 message VMValidationStatus {
-  VMValidationStatusCode code = 1;
-  string message = 2;
+    VMValidationStatusCode code = 1;
+    string message = 2;
 }
 
 message VMVerificationStatusList {
@@ -126,7 +126,7 @@ enum VMVerificationErrorKind {
     PopResourceError = 23;
     ReleaseRefTypeMismatchError = 24;
     BrTypeMismatchError = 25;
-    AssertTypeMismatchError = 26;
+    AbortTypeMismatchError = 26;
     StLocTypeMismatchError = 27;
     StLocUnsafeToDestroyError = 28;
     RetUnsafeToDestroyError = 29;
@@ -184,6 +184,7 @@ enum VMInvariantViolationError {
     LinkerError = 6;
     LocalReferenceError = 7;
     StorageError = 8;
+    InternalTypeError = 9;
 }
 
 // Errors that can arise from binary decoding (deserialization)
@@ -232,9 +233,9 @@ enum RuntimeStatus {
     DuplicateModuleName = 15;
 }
 
-// user-defined assertion error code number
-message AssertionFailure {
-    uint64 assertion_error_code = 1;
+// user-defined abort error code number
+message Aborted {
+    uint64 aborted_error_code = 1;
 }
 
 message ArithmeticError {
@@ -263,7 +264,7 @@ message DynamicReferenceError {
 message ExecutionStatus {
     oneof execution_status {
         RuntimeStatus runtime_status = 1;
-        AssertionFailure assertion_failure = 2;
+        Aborted aborted = 2;
         ArithmeticError arithmetic_error = 3;
         DynamicReferenceError reference_error = 4;
     }


### PR DESCRIPTION
I need these changes to continue working on integration tests but wanted to merge this separately to make PRs smaller. Changes:
- fixed signing ExtendedPrivKey and completed unit tests.
- added verifying of ExtendedPrivKey signatures, for testing purposes. I've used some code from #25. Found out that I actually need small verification function for testing purpose!
- (proposition) converting Move.peerToPeerTransfer to an eager singleton (will complain on startup if the file isn't there and if loaded successfully it can be reused without reading file anymore. Also if file is deleted from disc during runtime it will keep working).
- small fix in TransferExample, expiration time should be a timestamp, right?
- updated one .proto which has changed 