### PR TITLE
Use LibraHelper sign method for all signatures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,4 +38,4 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}
 
       # run tests!
-      - run: mvn verify
+      - run: mvn test

--- a/jlibra-core/src/main/java/dev/jlibra/KeyUtils.java
+++ b/jlibra-core/src/main/java/dev/jlibra/KeyUtils.java
@@ -48,7 +48,7 @@ public class KeyUtils {
         }
     }
 
-    private static KeyFactory getKeyFactory() {
+    public static KeyFactory getKeyFactory() {
         try {
             return KeyFactory.getInstance("Ed25519");
         } catch (NoSuchAlgorithmException e) {

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/AdmissionControl.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/AdmissionControl.java
@@ -16,7 +16,6 @@ import dev.jlibra.admissioncontrol.query.UpdateToLatestLedgerResult;
 import dev.jlibra.admissioncontrol.transaction.ImmutableSubmitTransactionResult;
 import dev.jlibra.admissioncontrol.transaction.SubmitTransactionResult;
 import dev.jlibra.admissioncontrol.transaction.Transaction;
-import dev.jlibra.mnemonic.ExtendedPrivKey;
 import io.grpc.Channel;
 import types.GetWithProof.RequestItem;
 import types.GetWithProof.UpdateToLatestLedgerRequest;
@@ -30,19 +29,10 @@ public class AdmissionControl {
         this.channel = channel;
     }
 
-    public SubmitTransactionResult submitTransaction(ExtendedPrivKey fromAccount, Transaction transaction) {
-        SubmitTransactionRequest request = toSubmitTransactionRequest(fromAccount, transaction, fromAccount::sign);
-
-        return submitTransaction(request);
-    }
-
-    public SubmitTransactionResult submitTransaction(PublicKey publicKey, PrivateKey privateKey, Transaction transaction) {
+    public SubmitTransactionResult submitTransaction(PublicKey publicKey, PrivateKey privateKey,
+            Transaction transaction) {
         SubmitTransactionRequest request = toSubmitTransactionRequest(publicKey, privateKey, transaction);
 
-        return submitTransaction(request);
-    }
-
-    private SubmitTransactionResult submitTransaction(SubmitTransactionRequest request) {
         AdmissionControlBlockingStub stub = AdmissionControlGrpc.newBlockingStub(channel);
         SubmitTransactionResponse response = stub.submitTransaction(request);
 
@@ -55,7 +45,6 @@ public class AdmissionControl {
     }
 
     public UpdateToLatestLedgerResult updateToLatestLedger(Query query) {
-
         AdmissionControlBlockingStub stub = AdmissionControlGrpc.newBlockingStub(channel);
 
         List<RequestItem> requestItems = new ArrayList<>();

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/RawTransactionSigner.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/RawTransactionSigner.java
@@ -1,7 +1,0 @@
-package dev.jlibra.admissioncontrol.transaction;
-
-import types.Transaction;
-import java.util.function.Function;
-
-public interface RawTransactionSigner extends Function<Transaction.RawTransaction, byte[]> {
-}

--- a/jlibra-core/src/test/java/dev/jlibra/mnemonic/ExtendedPrivKeyTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/mnemonic/ExtendedPrivKeyTest.java
@@ -1,16 +1,8 @@
 package dev.jlibra.mnemonic;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
-import dev.jlibra.admissioncontrol.transaction.AddressArgument;
-import dev.jlibra.admissioncontrol.transaction.U64Argument;
-import dev.jlibra.move.Move;
-import types.Transaction;
-
-import com.google.protobuf.ByteString;
+import java.security.Security;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.encoders.Hex;
@@ -18,9 +10,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.security.Security;
-import java.util.List;
+import dev.jlibra.KeyUtils;
 
 /**
  * Test data and mnemonic seed generated using libra cli.
@@ -36,7 +26,8 @@ public class ExtendedPrivKeyTest {
 
     @Before
     public void setUp() {
-        Mnemonic mnemonic = Mnemonic.fromString("aim layer grit goat orchard daring lady work dice lottery tent virus push heavy hello endless inner bread cliff brick swallow general method walnut");
+        Mnemonic mnemonic = Mnemonic.fromString(
+                "aim layer grit goat orchard daring lady work dice lottery tent virus push heavy hello endless inner bread cliff brick swallow general method walnut");
         Seed seed = new Seed(mnemonic, "LIBRA");
         LibraKeyFactory libraKeyFactory = new LibraKeyFactory(seed);
         childPrivate0 = libraKeyFactory.privateChild(new ChildNumber(0));
@@ -46,60 +37,14 @@ public class ExtendedPrivKeyTest {
     public void getAddress() {
         assertEquals(
                 "9263e21488ea4742c54de0d961c94743a01a974c6f095d8710f83044f0408ae7",
-                childPrivate0.getAddress()
-        );
+                childPrivate0.getAddress());
     }
 
     @Test
     public void getPublic() {
         assertEquals(
                 "be10d382d1f3de00c19607f667b5b127da22f42f0a3a4b70eaef690365421511",
-                childPrivate0.publicKey.toString()
-        );
+                Hex.toHexString(KeyUtils.stripPublicKeyPrefix(childPrivate0.publicKey.getEncoded())));
     }
 
-    /**
-     * From https://github.com/libra/libra/blob/master/client/libra_wallet/src/key_factory.rs:
-     *
-     * "NOTE: In Libra, we do not sign the raw bytes of a transaction, instead we sign the raw
-     *        bytes of the sha3 hash of the raw bytes of a transaction."
-     */
-    @Test
-    public void sign() throws IOException {
-        U64Argument amountArgument = new U64Argument(1_000_000);
-        AddressArgument addressArgument = new AddressArgument(Hex.decode(childPrivate0.getAddress()));
-        List<Transaction.TransactionArgument> transactionArguments = asList(
-                amountArgument.toGrpcTransactionArgument(),
-                addressArgument.toGrpcTransactionArgument()
-        );
-
-        Transaction.Program program = Transaction.Program.newBuilder()
-                .addAllArguments(transactionArguments)
-                .setCode(ByteString.readFrom(Move.peerToPeerTransfer()))
-                .addAllModules(emptyList())
-                .build();
-
-        Transaction.RawTransaction rawTransaction = Transaction.RawTransaction.newBuilder()
-                .setSequenceNumber(0)
-                .setMaxGasAmount(6000)
-                .setGasUnitPrice(1)
-                .setExpirationTime(10000)
-                .setProgram(program)
-                .build();
-
-        byte[] signature = childPrivate0.sign(rawTransaction);
-
-        assertEquals(
-                "0a026288ec43a0b44dc73bb386f69b1b0ef1374ec86577c30d5d3e64b57f4020ab219bb7b904c7c34f6f391e7f52568478569f8e11d7284f318bb2c00ddd1b0b",
-                Hex.toHexString(signature)
-        );
-    }
-
-    @Test
-    public void signAndVerifyMessageSuccessful() {
-        byte[] message = "The things I do for love.".getBytes();
-        byte[] signature = childPrivate0.sign(message);
-
-        assertTrue(childPrivate0.verify(signature, message));
-    }
 }

--- a/jlibra-core/src/test/java/dev/jlibra/mnemonic/LibraKeyFactoryTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/mnemonic/LibraKeyFactoryTest.java
@@ -1,17 +1,18 @@
 package dev.jlibra.mnemonic;
 
+import static org.junit.Assert.assertEquals;
+
+import java.security.Security;
+
 import org.bouncycastle.jcajce.provider.digest.SHA3;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.security.Security;
-
-import static org.junit.Assert.assertEquals;
-
 /**
- * Test data copied from https://github.com/libra/libra/blob/master/client/libra_wallet/src/key_factory.rs
+ * Test data copied from
+ * https://github.com/libra/libra/blob/master/client/libra_wallet/src/key_factory.rs
  */
 public class LibraKeyFactoryTest {
 
@@ -28,8 +29,7 @@ public class LibraKeyFactoryTest {
         byte[] digest = sha3.digest("abc".getBytes());
         assertEquals(
                 "3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532",
-                Hex.toHexString(digest)
-        );
+                Hex.toHexString(digest));
     }
 
     @Test
@@ -39,15 +39,13 @@ public class LibraKeyFactoryTest {
 
         assertEquals(
                 "8d8d9b85e36b2b9486becd31288e9dc2501cf77f95deb7d141eeb49d77f8a80f",
-                Hex.toHexString(seed.getData())
-        );
+                Hex.toHexString(seed.getData()));
 
         LibraKeyFactory libraKeyFactory = new LibraKeyFactory(seed);
 
         assertEquals(
                 "16274c9618ed59177ca948529c1884ba65c57984d562ec2b4e5aa1ee3e3903be",
-                Hex.toHexString(libraKeyFactory.getMaster().getData())
-        );
+                Hex.toHexString(libraKeyFactory.getMaster().getData()));
     }
 
     @Test
@@ -60,23 +58,20 @@ public class LibraKeyFactoryTest {
         ExtendedPrivKey childPrivate0 = libraKeyFactory.privateChild(new ChildNumber(0));
 
         assertEquals(
-                "358a375f36d74c30b7f3299b62d712b307725938f8cc931100fbd10a434fc8b9",
-                Hex.toHexString(childPrivate0.privateKey.getData())
-        );
+                "3051020101300506032b657004220420358a375f36d74c30b7f3299b62d712b307725938f8cc931100fbd10a434fc8b9812100b1894672e853ee6d2f1c094b0db2c2644edd4736f46c4357c709fdded5797c44",
+                Hex.toHexString(childPrivate0.privateKey.getEncoded()));
 
         // Check determinism, regenerate child_0.
         ExtendedPrivKey childPrivate0_again = libraKeyFactory.privateChild(new ChildNumber(0));
         assertEquals(
-                Hex.toHexString(childPrivate0.privateKey.getData()),
-                Hex.toHexString(childPrivate0_again.privateKey.getData())
-        );
+                Hex.toHexString(childPrivate0.privateKey.getEncoded()),
+                Hex.toHexString(childPrivate0_again.privateKey.getEncoded()));
 
         // Check child_1 key derivation.
         ExtendedPrivKey childPrivate1 = libraKeyFactory.privateChild(new ChildNumber(1));
         assertEquals(
-                "a325fe7d27b1b49f191cc03525951fec41b6ffa2d4b3007bb1d9dd353b7e56a6",
-                Hex.toHexString(childPrivate1.privateKey.getData())
-        );
+                "3051020101300506032b657004220420a325fe7d27b1b49f191cc03525951fec41b6ffa2d4b3007bb1d9dd353b7e56a6812100c66551332920eda683a977292305ef6c10c34b27d9fef331bbd851f5c74d09ee",
+                Hex.toHexString(childPrivate1.privateKey.getEncoded()));
 
         ChildNumber child1Again = new ChildNumber(0).increment();
         assertEquals(new ChildNumber(1).data, child1Again.data);
@@ -84,8 +79,7 @@ public class LibraKeyFactoryTest {
         // Check determinism, regenerate child_1, but by incrementing ChildNumber(0).
         ExtendedPrivKey childPrivate1FromIncrement = libraKeyFactory.privateChild(child1Again);
         assertEquals(
-                "a325fe7d27b1b49f191cc03525951fec41b6ffa2d4b3007bb1d9dd353b7e56a6",
-                Hex.toHexString(childPrivate1FromIncrement.privateKey.getData())
-        );
+                "3051020101300506032b657004220420a325fe7d27b1b49f191cc03525951fec41b6ffa2d4b3007bb1d9dd353b7e56a6812100c66551332920eda683a977292305ef6c10c34b27d9fef331bbd851f5c74d09ee",
+                Hex.toHexString(childPrivate1FromIncrement.privateKey.getEncoded()));
     }
 }


### PR DESCRIPTION
- I changed the implementation of the ExtendedPrivateKey to create PrivateKey and PublicKey objects, then this part can use the same signing as other parts of the code and there is no need for the separate method in the AdmissionControl for creating transactions with the mnemonic