### PR TITLE
Class for handling byte arrays #72

### DIFF
--- a/jlibra-core/src/main/java/dev/jlibra/AccountAddress.java
+++ b/jlibra-core/src/main/java/dev/jlibra/AccountAddress.java
@@ -2,41 +2,31 @@ package dev.jlibra;
 
 import java.security.PublicKey;
 
-import org.bouncycastle.util.encoders.Hex;
+import dev.jlibra.serialization.ByteSequence;
 
 public class AccountAddress {
 
-    private byte[] address;
+    private final ByteSequence byteSequence;
 
-    private AccountAddress(byte[] address) {
-        this.address = address;
-    }
-
-    public byte[] asByteArray() {
-        byte[] clone = new byte[address.length];
-        System.arraycopy(address, 0, clone, 0, address.length);
-        return clone;
-    }
-
-    public String asHexString() {
-        return Hex.toHexString(address);
+    private AccountAddress(ByteSequence byteSequence) {
+        this.byteSequence = byteSequence;
     }
 
     public static AccountAddress ofPublicKey(PublicKey publicKey) {
-        return new AccountAddress(KeyUtils.toByteArrayLibraAddress(publicKey.getEncoded()));
+        return new AccountAddress(KeyUtils.toByteSequenceLibraAddress(ByteSequence.from(publicKey.getEncoded())));
     }
 
-    public static AccountAddress ofByteArray(byte[] address) {
+    public static AccountAddress ofByteSequence(ByteSequence address) {
         return new AccountAddress(address);
     }
 
-    public static AccountAddress ofHexString(String hexString) {
-        return new AccountAddress(Hex.decode(hexString));
+    public ByteSequence getByteSequence() {
+        return byteSequence;
     }
 
     @Override
     public String toString() {
-        return String.format("AccountAddress: %s", Hex.toHexString(address));
+        return String.format("AccountAddress: %s", byteSequence);
     }
 
 }

--- a/jlibra-core/src/main/java/dev/jlibra/KeyUtils.java
+++ b/jlibra-core/src/main/java/dev/jlibra/KeyUtils.java
@@ -25,7 +25,7 @@ public class KeyUtils {
         return pubKeyBytes.subseq(12, 32);
     }
 
-    public static PrivateKey privateKeyFromHexString(ByteSequence privateKey) {
+    public static PrivateKey privateKeyFromByteSequence(ByteSequence privateKey) {
         try {
             return getKeyFactory().generatePrivate(new PKCS8EncodedKeySpec(privateKey.toArray()));
         } catch (InvalidKeySpecException e) {
@@ -33,7 +33,7 @@ public class KeyUtils {
         }
     }
 
-    public static PublicKey publicKeyFromHexString(ByteSequence publicKey) {
+    public static PublicKey publicKeyFromByteSequence(ByteSequence publicKey) {
         try {
             return getKeyFactory().generatePublic(new X509EncodedKeySpec(publicKey.toArray()));
         } catch (InvalidKeySpecException e) {

--- a/jlibra-core/src/main/java/dev/jlibra/KeyUtils.java
+++ b/jlibra-core/src/main/java/dev/jlibra/KeyUtils.java
@@ -9,40 +9,33 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
 import org.bouncycastle.jcajce.provider.digest.SHA3;
-import org.bouncycastle.util.encoders.Hex;
+
+import dev.jlibra.serialization.ByteSequence;
 
 public class KeyUtils {
 
-    public static String toHexStringLibraAddress(byte[] publicKeyBytes) {
-        return Hex.toHexString(toByteArrayLibraAddress(publicKeyBytes));
-    }
-
-    public static byte[] toByteArrayLibraAddress(byte[] publicKeyBytes) {
+    public static ByteSequence toByteSequenceLibraAddress(ByteSequence publicKeyBytes) {
         SHA3.DigestSHA3 digestSHA3 = new SHA3.Digest256();
-        return digestSHA3.digest(stripPublicKeyPrefix(publicKeyBytes));
+        return ByteSequence
+                .from(digestSHA3
+                .digest(stripPublicKeyPrefix(publicKeyBytes).toArray()));
     }
 
-    public static byte[] stripPublicKeyPrefix(byte[] pubKeyBytes) {
-        byte[] publicKeyWithoutPrefix = new byte[32];
-        System.arraycopy(pubKeyBytes, 12, publicKeyWithoutPrefix, 0, 32);
-        return publicKeyWithoutPrefix;
+    public static ByteSequence stripPublicKeyPrefix(ByteSequence pubKeyBytes) {
+        return pubKeyBytes.subseq(12, 32);
     }
 
-    public static PrivateKey privateKeyFromHexString(String privateKeyHexString) {
-        byte[] privateKeyBytes = Hex.decode(privateKeyHexString);
-
+    public static PrivateKey privateKeyFromHexString(ByteSequence privateKey) {
         try {
-            return getKeyFactory().generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
+            return getKeyFactory().generatePrivate(new PKCS8EncodedKeySpec(privateKey.toArray()));
         } catch (InvalidKeySpecException e) {
             throw new LibraRuntimeException("PrivateKey generation failed", e);
         }
     }
 
-    public static PublicKey publicKeyFromHexString(String publicKeyHexString) {
-        byte[] publicKeyBytes = Hex.decode(publicKeyHexString);
-
+    public static PublicKey publicKeyFromHexString(ByteSequence publicKey) {
         try {
-            return getKeyFactory().generatePublic(new X509EncodedKeySpec(publicKeyBytes));
+            return getKeyFactory().generatePublic(new X509EncodedKeySpec(publicKey.toArray()));
         } catch (InvalidKeySpecException e) {
             throw new LibraRuntimeException("PrivateKey generation failed", e);
         }

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/AccountResource.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/AccountResource.java
@@ -1,7 +1,7 @@
 package dev.jlibra.admissioncontrol.query;
 
 import static dev.jlibra.serialization.Deserialization.readBoolean;
-import static dev.jlibra.serialization.Deserialization.readBytes;
+import static dev.jlibra.serialization.Deserialization.readByteSequence;
 import static dev.jlibra.serialization.Deserialization.readInt;
 import static dev.jlibra.serialization.Deserialization.readLong;
 
@@ -14,12 +14,13 @@ import java.util.List;
 import org.immutables.value.Value;
 
 import dev.jlibra.LibraRuntimeException;
+import dev.jlibra.serialization.ByteSequence;
 import types.AccountStateBlobOuterClass.AccountStateWithProof;
 
 @Value.Immutable
 public interface AccountResource {
 
-    byte[] getAuthenticationKey();
+    ByteSequence getAuthenticationKey();
 
     long getBalanceInMicroLibras();
 
@@ -33,10 +34,10 @@ public interface AccountResource {
 
     boolean getDelegatedKeyRotationCapability();
 
-    static AccountResource deserialize(byte[] bytes) {
-        try (DataInputStream accountDataStream = new DataInputStream(new ByteArrayInputStream(bytes))) {
+    static AccountResource deserialize(ByteSequence byteSequence) {
+        try (DataInputStream accountDataStream = new DataInputStream(new ByteArrayInputStream(byteSequence.toArray()))) {
             int addressLength = readInt(accountDataStream, 4);
-            byte[] address = readBytes(accountDataStream, addressLength);
+            ByteSequence address = readByteSequence(accountDataStream, addressLength);
             long balance = readLong(accountDataStream, 8);
             boolean delegatedKeyRotationCapability = readBoolean(accountDataStream);
             boolean delegatedWithdrawalCapability = readBoolean(accountDataStream);
@@ -46,14 +47,14 @@ public interface AccountResource {
             readInt(accountDataStream, 4);
             EventHandle receivedEvents = ImmutableEventHandle.builder()
                     .count(receivedEventsCount)
-                    .key(readBytes(accountDataStream, readInt(accountDataStream, 4)))
+                    .key(readByteSequence(accountDataStream, readInt(accountDataStream, 4)))
                     .build();
 
             int sentEventsCount = readInt(accountDataStream, 4);
             // skip struct attribute sequence number
             readInt(accountDataStream, 4);
             EventHandle sentEvents = ImmutableEventHandle.builder()
-                    .key(readBytes(accountDataStream, readInt(accountDataStream, 4)))
+                    .key(readByteSequence(accountDataStream, readInt(accountDataStream, 4)))
                     .count(sentEventsCount)
                     .build();
 
@@ -80,9 +81,9 @@ public interface AccountResource {
 
         for (int i = 0; i < dataSize; i++) {
             int keyLength = readInt(in, 4);
-            byte[] key = readBytes(in, keyLength);
+            ByteSequence keyValue = readByteSequence(in, keyLength);
             int valLength = readInt(in, 4);
-            byte[] val = readBytes(in, valLength);
+            ByteSequence val = readByteSequence(in, valLength);
             accountResources.add(AccountResource.deserialize(val));
         }
 

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/Event.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/Event.java
@@ -8,6 +8,7 @@ import org.immutables.value.Value;
 
 import dev.jlibra.AccountAddress;
 import dev.jlibra.LibraRuntimeException;
+import dev.jlibra.serialization.ByteSequence;
 import dev.jlibra.serialization.Deserialization;
 
 @Value.Immutable
@@ -17,7 +18,7 @@ public interface Event {
 
     long getAmount();
 
-    byte[] getKey();
+    ByteSequence getKey();
 
     long getSequenceNumber();
 
@@ -25,11 +26,11 @@ public interface Event {
         byte[] eventData = event.getEventData().toByteArray();
         try (DataInputStream eventDataStream = new DataInputStream(new ByteArrayInputStream(eventData))) {
             long amount = Deserialization.readLong(eventDataStream, 8);
-            byte[] address = Deserialization.readBytes(eventDataStream, 32);
+            ByteSequence address = Deserialization.readByteSequence(eventDataStream, 32);
             return ImmutableEvent.builder()
-                    .accountAddress(AccountAddress.ofByteArray(address))
+                    .accountAddress(AccountAddress.ofByteSequence(address))
                     .amount(amount)
-                    .key(event.getKey().toByteArray())
+                    .key(ByteSequence.from(event.getKey().toByteArray()))
                     .sequenceNumber(event.getSequenceNumber())
                     .build();
         } catch (IOException e) {

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/EventHandle.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/EventHandle.java
@@ -2,10 +2,12 @@ package dev.jlibra.admissioncontrol.query;
 
 import org.immutables.value.Value;
 
+import dev.jlibra.serialization.ByteSequence;
+
 @Value.Immutable
 public interface EventHandle {
 
-    byte[] getKey();
+    ByteSequence getKey();
 
     int getCount();
 

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/GetAccountState.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/GetAccountState.java
@@ -2,8 +2,6 @@ package dev.jlibra.admissioncontrol.query;
 
 import org.immutables.value.Value;
 
-import com.google.protobuf.ByteString;
-
 import dev.jlibra.AccountAddress;
 import types.GetWithProof.GetAccountStateRequest;
 import types.GetWithProof.RequestItem;
@@ -15,7 +13,7 @@ public abstract class GetAccountState {
 
     public RequestItem toGrpcObject() {
         GetAccountStateRequest getAccountStateRequest = GetAccountStateRequest.newBuilder()
-                .setAddress(ByteString.copyFrom(getAddress().asByteArray()))
+                .setAddress(getAddress().getByteSequence().toByteString())
                 .build();
         return RequestItem.newBuilder()
                 .setGetAccountStateRequest(getAccountStateRequest)

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/GetAccountTransactionBySequenceNumber.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/GetAccountTransactionBySequenceNumber.java
@@ -2,8 +2,6 @@ package dev.jlibra.admissioncontrol.query;
 
 import org.immutables.value.Value;
 
-import com.google.protobuf.ByteString;
-
 import dev.jlibra.AccountAddress;
 import types.GetWithProof.GetAccountTransactionBySequenceNumberRequest;
 import types.GetWithProof.RequestItem;
@@ -18,7 +16,7 @@ public abstract class GetAccountTransactionBySequenceNumber {
     public RequestItem toGrpcObject() {
         GetAccountTransactionBySequenceNumberRequest getAccountTransactionBySequenceNumberRequest = GetAccountTransactionBySequenceNumberRequest
                 .newBuilder()
-                .setAccount(ByteString.copyFrom(getAccountAddress().asByteArray()))
+                .setAccount(getAccountAddress().getByteSequence().toByteString())
                 .setSequenceNumber(getSequenceNumber())
                 .setFetchEvents(true)
                 .build();

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/AccountAddressArgument.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/AccountAddressArgument.java
@@ -1,22 +1,23 @@
 package dev.jlibra.admissioncontrol.transaction;
 
+import dev.jlibra.serialization.ByteSequence;
 import dev.jlibra.serialization.Serializer;
 
 public class AccountAddressArgument implements TransactionArgument {
 
     private static final int PREFIX = 1;
 
-    private byte[] address;
+    private ByteSequence address;
 
-    public AccountAddressArgument(byte[] address) {
+    public AccountAddressArgument(ByteSequence address) {
         this.address = address;
     }
 
     @Override
-    public byte[] serialize() {
+    public ByteSequence serialize() {
         return Serializer.builder()
                 .appendInt(PREFIX)
-                .appendByteArrayWithoutLengthInformation(address)
-                .toByteArray();
+                .appendWithoutLengthInformation(address)
+                .toByteSequence();
     }
 }

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/ByteArrayArgument.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/ByteArrayArgument.java
@@ -1,22 +1,23 @@
 package dev.jlibra.admissioncontrol.transaction;
 
+import dev.jlibra.serialization.ByteSequence;
 import dev.jlibra.serialization.Serializer;
 
 public class ByteArrayArgument implements TransactionArgument {
 
     private static final int PREFIX = 3;
 
-    private byte[] bytes;
+    private ByteSequence bytes;
 
-    public ByteArrayArgument(byte[] bytes) {
+    public ByteArrayArgument(ByteSequence bytes) {
         this.bytes = bytes;
     }
 
     @Override
-    public byte[] serialize() {
+    public ByteSequence serialize() {
         return Serializer.builder()
                 .appendInt(PREFIX)
-                .appendByteArray(bytes)
-                .toByteArray();
+                .append(bytes)
+                .toByteSequence();
     }
 }

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/Script.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/Script.java
@@ -4,26 +4,25 @@ import java.util.List;
 
 import org.immutables.value.Value;
 
-import com.google.protobuf.ByteString;
-
+import dev.jlibra.serialization.ByteSequence;
 import dev.jlibra.serialization.LibraSerializable;
 import dev.jlibra.serialization.Serializer;
 
 @Value.Immutable
 public interface Script extends LibraSerializable {
 
-    static final int PREFIX = 2;
+    int PREFIX = 2;
 
-    ByteString getCode();
+    ByteSequence getCode();
 
     List<TransactionArgument> getArguments();
 
-    default byte[] serialize() {
+    default ByteSequence serialize() {
         return Serializer.builder()
                 .appendInt(PREFIX)
-                .appendByteArray(getCode().toByteArray())
+                .append(getCode())
                 .appendTransactionArguments(getArguments())
-                .toByteArray();
+                .toByteSequence();
     }
 
 }

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/SignedTransaction.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/SignedTransaction.java
@@ -4,9 +4,8 @@ import java.security.PublicKey;
 
 import org.immutables.value.Value;
 
-import com.google.protobuf.ByteString;
-
 import admission_control.AdmissionControlOuterClass.SubmitTransactionRequest;
+import dev.jlibra.serialization.ByteSequence;
 import dev.jlibra.serialization.LibraSerializable;
 import dev.jlibra.serialization.Serializer;
 
@@ -19,18 +18,18 @@ public abstract class SignedTransaction implements LibraSerializable {
 
     public abstract Signature getSignature();
 
-    public byte[] serialize() {
+    public ByteSequence serialize() {
         return Serializer.builder()
                 .appendSerializable(getTransaction())
                 .appendPublicKey(getPublicKey())
                 .appendSerializable(getSignature())
-                .toByteArray();
+                .toByteSequence();
     }
 
     public SubmitTransactionRequest toGrpcObject() {
         types.TransactionOuterClass.SignedTransaction signedTransaction = types.TransactionOuterClass.SignedTransaction
                 .newBuilder()
-                .setTxnBytes(ByteString.copyFrom(serialize()))
+                .setTxnBytes(serialize().toByteString())
                 .build();
         return SubmitTransactionRequest.newBuilder()
                 .setTransaction(signedTransaction)

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/StringArgument.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/StringArgument.java
@@ -1,5 +1,6 @@
 package dev.jlibra.admissioncontrol.transaction;
 
+import dev.jlibra.serialization.ByteSequence;
 import dev.jlibra.serialization.Serializer;
 
 public class StringArgument implements TransactionArgument {
@@ -13,11 +14,11 @@ public class StringArgument implements TransactionArgument {
     }
 
     @Override
-    public byte[] serialize() {
+    public ByteSequence serialize() {
         return Serializer.builder()
                 .appendInt(PREFIX)
                 .appendString(value)
-                .toByteArray();
+                .toByteSequence();
     }
 
 }

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/Transaction.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/Transaction.java
@@ -3,6 +3,7 @@ package dev.jlibra.admissioncontrol.transaction;
 import org.immutables.value.Value;
 
 import dev.jlibra.AccountAddress;
+import dev.jlibra.serialization.ByteSequence;
 import dev.jlibra.serialization.LibraSerializable;
 import dev.jlibra.serialization.Serializer;
 
@@ -21,15 +22,15 @@ public interface Transaction extends LibraSerializable {
 
     long getMaxGasAmount();
 
-    default byte[] serialize() {
+    default ByteSequence serialize() {
         return Serializer.builder()
-                .appendByteArrayWithoutLengthInformation(getSenderAccount().asByteArray())
+                .appendWithoutLengthInformation(getSenderAccount().getByteSequence())
                 .appendLong(getSequenceNumber())
                 .appendSerializable(getPayload())
                 .appendLong(getMaxGasAmount())
                 .appendLong(getGasUnitPrice())
                 .appendLong(getExpirationTime())
-                .toByteArray();
+                .toByteSequence();
     }
 
 }

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/U64Argument.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/U64Argument.java
@@ -1,5 +1,6 @@
 package dev.jlibra.admissioncontrol.transaction;
 
+import dev.jlibra.serialization.ByteSequence;
 import dev.jlibra.serialization.Serializer;
 
 public class U64Argument implements TransactionArgument {
@@ -13,11 +14,11 @@ public class U64Argument implements TransactionArgument {
     }
 
     @Override
-    public byte[] serialize() {
+    public ByteSequence serialize() {
         return Serializer.builder()
                 .appendInt(PREFIX)
                 .appendLong(value)
-                .toByteArray();
+                .toByteSequence();
     }
 
 }

--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/result/SubmitTransactionResult.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/transaction/result/SubmitTransactionResult.java
@@ -4,6 +4,7 @@ import org.immutables.value.Value;
 
 import admission_control.AdmissionControlOuterClass.AdmissionControlStatusCode;
 import admission_control.AdmissionControlOuterClass.SubmitTransactionResponse;
+import dev.jlibra.serialization.ByteSequence;
 
 /**
  * The only case where the transaction has been submitted successfully is when
@@ -14,7 +15,7 @@ import admission_control.AdmissionControlOuterClass.SubmitTransactionResponse;
 @Value.Immutable
 public abstract class SubmitTransactionResult {
 
-    public abstract byte[] getValidatorId();
+    public abstract ByteSequence getValidatorId();
 
     public static SubmitTransactionResult fromGrpcObject(SubmitTransactionResponse response)
             throws LibraTransactionException {
@@ -22,7 +23,7 @@ public abstract class SubmitTransactionResult {
         case AC_STATUS: {
             if (response.getAcStatus().getCode() == AdmissionControlStatusCode.Accepted) {
                 return ImmutableSubmitTransactionResult.builder()
-                        .validatorId(response.getValidatorId().toByteArray())
+                        .validatorId(ByteSequence.from(response.getValidatorId().toByteArray()))
                         .build();
             }
             throw new LibraAdmissionControlException(response.getAcStatus().getCode(),

--- a/jlibra-core/src/main/java/dev/jlibra/mnemonic/ExtendedPrivKey.java
+++ b/jlibra-core/src/main/java/dev/jlibra/mnemonic/ExtendedPrivKey.java
@@ -8,7 +8,6 @@ import java.security.spec.PKCS8EncodedKeySpec;
 
 import javax.annotation.concurrent.Immutable;
 
-import dev.jlibra.LibraRuntimeException;
 import org.bouncycastle.asn1.edec.EdECObjectIdentifiers;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
@@ -18,6 +17,8 @@ import org.bouncycastle.crypto.util.PrivateKeyInfoFactory;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import dev.jlibra.KeyUtils;
+import dev.jlibra.LibraRuntimeException;
+import dev.jlibra.serialization.ByteSequence;
 
 @Immutable
 public class ExtendedPrivKey {
@@ -26,7 +27,7 @@ public class ExtendedPrivKey {
     public final PublicKey publicKey;
 
     public ExtendedPrivKey(SecretKey secretKey) {
-        Ed25519PrivateKeyParameters pKeyParams = new Ed25519PrivateKeyParameters(secretKey.getData(), 0);
+        Ed25519PrivateKeyParameters pKeyParams = new Ed25519PrivateKeyParameters(secretKey.getByteSequence().toArray(), 0);
 
         try {
             PrivateKeyInfo keyInfo = PrivateKeyInfoFactory.createPrivateKeyInfo(pKeyParams);
@@ -39,6 +40,7 @@ public class ExtendedPrivKey {
     }
 
     public String getAddress() {
-        return KeyUtils.toHexStringLibraAddress(publicKey.getEncoded());
+        ByteSequence publicKeyBytes = ByteSequence.from(publicKey.getEncoded());
+        return KeyUtils.toByteSequenceLibraAddress(publicKeyBytes).toString();
     }
 }

--- a/jlibra-core/src/main/java/dev/jlibra/mnemonic/LibraKeyFactory.java
+++ b/jlibra-core/src/main/java/dev/jlibra/mnemonic/LibraKeyFactory.java
@@ -1,14 +1,16 @@
 package dev.jlibra.mnemonic;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
 import org.bouncycastle.crypto.digests.SHA3Digest;
 import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
 import org.bouncycastle.crypto.macs.HMac;
 import org.bouncycastle.crypto.params.HKDFParameters;
 import org.bouncycastle.crypto.params.KeyParameter;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
+import dev.jlibra.serialization.ByteSequence;
 
 public class LibraKeyFactory {
 
@@ -40,7 +42,7 @@ public class LibraKeyFactory {
         hkdf.init(HKDFParameters.skipExtractParameters(master.getData(), info));
         hkdf.generateBytes(secretKey, 0, 32);
 
-        return new ExtendedPrivKey(new SecretKey(secretKey));
+        return new ExtendedPrivKey(new SecretKey(ByteSequence.from(secretKey)));
     }
 
     /**

--- a/jlibra-core/src/main/java/dev/jlibra/mnemonic/Mnemonic.java
+++ b/jlibra-core/src/main/java/dev/jlibra/mnemonic/Mnemonic.java
@@ -1,13 +1,17 @@
 package dev.jlibra.mnemonic;
 
-import javax.annotation.concurrent.Immutable;
+import static java.util.Arrays.asList;
+
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.annotation.concurrent.Immutable;
 
 import dev.jlibra.LibraRuntimeException;
-
-import static java.util.Arrays.asList;
+import dev.jlibra.serialization.ByteSequence;
 
 @Immutable
 public class Mnemonic {
@@ -245,7 +249,8 @@ public class Mnemonic {
         return new Mnemonic(words);
     }
 
-    public static Mnemonic fromBytes(byte[] data) {
+    public static Mnemonic fromByteSequence(ByteSequence byteSequence) {
+        byte[] data = byteSequence.toArray();
         if (data == null || data.length % 4 != 0) {
             throw new LibraRuntimeException("Data for mnemonic should have a length divisible by 4");
         }

--- a/jlibra-core/src/main/java/dev/jlibra/mnemonic/SecretKey.java
+++ b/jlibra-core/src/main/java/dev/jlibra/mnemonic/SecretKey.java
@@ -1,29 +1,29 @@
 package dev.jlibra.mnemonic;
 
-import dev.jlibra.LibraRuntimeException;
-import org.bouncycastle.util.encoders.Hex;
-
 import javax.annotation.concurrent.Immutable;
+
+import dev.jlibra.LibraRuntimeException;
+import dev.jlibra.serialization.ByteSequence;
 
 @Immutable
 public class SecretKey {
 
-    private final byte[] data;
+    private final ByteSequence byteSequence;
 
-    public SecretKey(byte[] data) {
+    public SecretKey(ByteSequence byteSequence) {
+        this.byteSequence = byteSequence;
+        byte[] data = byteSequence.toArray();
         if (data == null || data.length != 32) {
             throw new LibraRuntimeException("SecretKey requires 32 bytes but found " + (data == null ? 0 : data.length));
         }
-
-        this.data = data.clone();
     }
 
-    public byte[] getData() {
-        return data.clone();
+    public ByteSequence getByteSequence() {
+        return byteSequence;
     }
 
     @Override
     public String toString() {
-        return Hex.toHexString(data);
+        return byteSequence.toString();
     }
 }

--- a/jlibra-core/src/main/java/dev/jlibra/mnemonic/Seed.java
+++ b/jlibra-core/src/main/java/dev/jlibra/mnemonic/Seed.java
@@ -1,12 +1,13 @@
 package dev.jlibra.mnemonic;
 
-import javax.annotation.concurrent.Immutable;
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
+
+import javax.annotation.concurrent.Immutable;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 
 import dev.jlibra.LibraRuntimeException;
 

--- a/jlibra-core/src/main/java/dev/jlibra/move/Move.java
+++ b/jlibra-core/src/main/java/dev/jlibra/move/Move.java
@@ -1,23 +1,25 @@
 package dev.jlibra.move;
 
+import static java.util.stream.Collectors.joining;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
-import static java.util.stream.Collectors.joining;
+import dev.jlibra.serialization.ByteSequence;
 
 public class Move {
 
-    public static byte[] rotateAuthenticationKeyAsBytes() {
+    public static ByteSequence rotateAuthenticationKeyAsBytes() {
         return readMoveScriptBytes("/move/rotate_authentication_key.json");
     }
 
-    public static byte[] peerToPeerTransferAsBytes() {
+    public static ByteSequence peerToPeerTransferAsBytes() {
         return readMoveScriptBytes("/move/peer_to_peer_transfer.json");
     }
 
-    private static byte[] readMoveScriptBytes(String fileName) {
+    private static ByteSequence readMoveScriptBytes(String fileName) {
         InputStream jsonBinary = Move.class.getResourceAsStream(fileName);
         String json = readJson(jsonBinary);
         String[] bytesAsString = json.substring(json.indexOf('[') + 1, json.indexOf(']')).split(",");
@@ -25,7 +27,7 @@ public class Move {
         for (int idx = 0; idx < bytesAsString.length; idx++) {
             bytes[idx] = (byte) Integer.parseInt(bytesAsString[idx]);
         }
-        return bytes;
+        return ByteSequence.from(bytes);
     }
 
     private static String readJson(InputStream inputStream) {

--- a/jlibra-core/src/main/java/dev/jlibra/serialization/ByteSequence.java
+++ b/jlibra-core/src/main/java/dev/jlibra/serialization/ByteSequence.java
@@ -1,5 +1,7 @@
 package dev.jlibra.serialization;
 
+import java.util.Arrays;
+
 import javax.annotation.concurrent.Immutable;
 
 import org.bouncycastle.util.encoders.Hex;
@@ -10,17 +12,15 @@ import com.google.protobuf.ByteString;
 public class ByteSequence {
 
     private final byte[] value;
-    private final String hexValue;
 
     private ByteSequence(byte[] array) {
-        value = array;
-        hexValue = Hex.toHexString(value);
+        byte[] cloned = new byte[array.length];
+        System.arraycopy(array, 0, cloned, 0, array.length);
+        value = cloned;
     }
 
     public static ByteSequence from(byte[] array) {
-        byte[] result = new byte[array.length];
-        System.arraycopy(array, 0, result, 0, array.length);
-        return new ByteSequence(result);
+        return new ByteSequence(array);
     }
 
     public static ByteSequence from(String hexValue) {
@@ -28,7 +28,7 @@ public class ByteSequence {
     }
 
     public String toString() {
-        return hexValue;
+        return Hex.toHexString(value);
     }
 
     public ByteSequence subseq(int start, int length) {
@@ -55,10 +55,10 @@ public class ByteSequence {
 
         ByteSequence that = (ByteSequence) o;
 
-        return hexValue.equals(that.hexValue);
+        return Arrays.equals(this.value, that.value);
     }
 
     @Override public int hashCode() {
-        return hexValue.hashCode();
+        return Arrays.hashCode(this.value);
     }
 }

--- a/jlibra-core/src/main/java/dev/jlibra/serialization/ByteSequence.java
+++ b/jlibra-core/src/main/java/dev/jlibra/serialization/ByteSequence.java
@@ -1,0 +1,64 @@
+package dev.jlibra.serialization;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.bouncycastle.util.encoders.Hex;
+
+import com.google.protobuf.ByteString;
+
+@Immutable
+public class ByteSequence {
+
+    private final byte[] value;
+    private final String hexValue;
+
+    private ByteSequence(byte[] array) {
+        value = array;
+        hexValue = Hex.toHexString(value);
+    }
+
+    public static ByteSequence from(byte[] array) {
+        byte[] result = new byte[array.length];
+        System.arraycopy(array, 0, result, 0, array.length);
+        return new ByteSequence(result);
+    }
+
+    public static ByteSequence from(String hexValue) {
+        return new ByteSequence(Hex.decode(hexValue));
+    }
+
+    public String toString() {
+        return hexValue;
+    }
+
+    public ByteSequence subseq(int start, int length) {
+        byte[] result = new byte[length];
+        System.arraycopy(value, start, result, 0, length);
+        return new ByteSequence(result);
+    }
+
+    public byte[] toArray() {
+        byte[] result = new byte[value.length];
+        System.arraycopy(value, 0, result, 0, value.length);
+        return result;
+    }
+
+    public ByteString toByteString() {
+        return ByteString.copyFrom(value);
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof ByteSequence))
+            return false;
+
+        ByteSequence that = (ByteSequence) o;
+
+        return hexValue.equals(that.hexValue);
+    }
+
+    @Override public int hashCode() {
+        return hexValue.hashCode();
+    }
+}

--- a/jlibra-core/src/main/java/dev/jlibra/serialization/Deserialization.java
+++ b/jlibra-core/src/main/java/dev/jlibra/serialization/Deserialization.java
@@ -24,7 +24,11 @@ public class Deserialization {
         return data[0] == 1;
     }
 
-    public static byte[] readBytes(InputStream in, int len) {
+    public static ByteSequence readByteSequence(InputStream in, int len) {
+        return ByteSequence.from(readBytes(in, len));
+    }
+
+    private static byte[] readBytes(InputStream in, int len) {
         byte[] data = new byte[len];
         try {
             in.read(data);

--- a/jlibra-core/src/main/java/dev/jlibra/serialization/LibraSerializable.java
+++ b/jlibra-core/src/main/java/dev/jlibra/serialization/LibraSerializable.java
@@ -1,5 +1,5 @@
 package dev.jlibra.serialization;
 
 public interface LibraSerializable {
-    byte[] serialize();
+    ByteSequence serialize();
 }

--- a/jlibra-core/src/main/java/dev/jlibra/serialization/Serializer.java
+++ b/jlibra-core/src/main/java/dev/jlibra/serialization/Serializer.java
@@ -22,23 +22,27 @@ public class Serializer {
         return new Serializer(new byte[0]);
     }
 
-    public Serializer appendByteArray(byte[] byteArray) {
+    public Serializer append(ByteSequence byteSequence) {
+        return appendByteArray(byteSequence.toArray());
+    }
+
+    private Serializer appendByteArray(byte[] byteArray) {
         return append(intToByteArray(byteArray.length))
                 .append(byteArray);
     }
 
     public Serializer appendPublicKey(PublicKey pubKey) {
-        return appendByteArray(KeyUtils.stripPublicKeyPrefix(pubKey.getEncoded()));
+        return append(KeyUtils.stripPublicKeyPrefix(ByteSequence.from(pubKey.getEncoded())));
     }
 
-    public Serializer appendByteArrayWithoutLengthInformation(byte[] byteArray) {
-        return append(byteArray);
+    public Serializer appendWithoutLengthInformation(ByteSequence byteSequence) {
+        return append(byteSequence.toArray());
     }
 
     public Serializer appendTransactionArguments(List<TransactionArgument> transactionArguments) {
         Serializer serializer = append(intToByteArray(transactionArguments.size()));
         for (TransactionArgument arg : transactionArguments) {
-            serializer = serializer.append(arg.serialize());
+            serializer = serializer.append(arg.serialize().toArray());
         }
         return serializer;
     }
@@ -56,7 +60,7 @@ public class Serializer {
     }
 
     public Serializer appendSerializable(LibraSerializable serializable) {
-        return append(serializable.serialize());
+        return append(serializable.serialize().toArray());
     }
 
     private static byte[] intToByteArray(int i) {
@@ -78,14 +82,7 @@ public class Serializer {
         return new Serializer(newBytes);
     }
 
-    public byte[] toByteArray() {
-        return clone(bytes);
+    public ByteSequence toByteSequence() {
+        return ByteSequence.from(bytes);
     }
-
-    private byte[] clone(byte[] array) {
-        byte[] clone = new byte[array.length];
-        System.arraycopy(array, 0, clone, 0, array.length);
-        return clone;
-    }
-
 }

--- a/jlibra-core/src/test/java/dev/jlibra/KeyUtilsTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/KeyUtilsTest.java
@@ -30,13 +30,13 @@ public class KeyUtilsTest {
     @Test
     public void testPrivateKeyFromHexString() throws Exception {
         PrivateKey privateKey = getKeyFactory().generatePrivate(new PKCS8EncodedKeySpec(PRIVATE_KEY.toArray()));
-        assertThat(privateKey, equalTo(KeyUtils.privateKeyFromHexString(PRIVATE_KEY)));
+        assertThat(privateKey, equalTo(KeyUtils.privateKeyFromByteSequence(PRIVATE_KEY)));
     }
 
     @Test
     public void testPublicKeyFromHexString() throws Exception {
         PublicKey publicKey = getKeyFactory().generatePublic(new X509EncodedKeySpec(PUBLIC_KEY.toArray()));
-        assertThat(publicKey, equalTo(KeyUtils.publicKeyFromHexString(PUBLIC_KEY)));
+        assertThat(publicKey, equalTo(KeyUtils.publicKeyFromByteSequence(PUBLIC_KEY)));
     }
 
     private static KeyFactory getKeyFactory() throws Exception {

--- a/jlibra-core/src/test/java/dev/jlibra/KeyUtilsTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/KeyUtilsTest.java
@@ -1,7 +1,6 @@
 package dev.jlibra;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 import java.security.KeyFactory;
@@ -11,14 +10,17 @@ import java.security.Security;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import dev.jlibra.serialization.ByteSequence;
+
 public class KeyUtilsTest {
 
-    private static final String PRIVATE_KEY_HEX = "3051020101300506032b6570042204206dadf7a252c0e74add2e545a1e3c811f1f4bdd88f8c5e0080e068f4df6d909128121000b29a7adce0897b2d1ec18cc482237463efa173945fa3bd2703023e1a2489021";
-    private static final String PUBLIC_KEY_HEX = "302a300506032b65700321000b29a7adce0897b2d1ec18cc482237463efa173945fa3bd2703023e1a2489021";
+    private static final ByteSequence PRIVATE_KEY = ByteSequence
+            .from("3051020101300506032b6570042204206dadf7a252c0e74add2e545a1e3c811f1f4bdd88f8c5e0080e068f4df6d909128121000b29a7adce0897b2d1ec18cc482237463efa173945fa3bd2703023e1a2489021");
+    private static final ByteSequence PUBLIC_KEY = ByteSequence
+            .from("302a300506032b65700321000b29a7adce0897b2d1ec18cc482237463efa173945fa3bd2703023e1a2489021");
 
     @BeforeClass
     public static void setUpClass() {
@@ -26,28 +28,15 @@ public class KeyUtilsTest {
     }
 
     @Test
-    public void testHexStringToLibraAddress() throws Exception {
-        PublicKey publicKey = getKeyFactory().generatePublic(new X509EncodedKeySpec(Hex
-                .decode(PUBLIC_KEY_HEX)));
-
-        assertThat(KeyUtils.toHexStringLibraAddress(publicKey.getEncoded()),
-                is("eb99fc3808a8e439c58f87935cbe6774e4cc83459b463ea0813b34ef96f0ba87"));
-    }
-
-    @Test
     public void testPrivateKeyFromHexString() throws Exception {
-        PrivateKey privateKey = getKeyFactory().generatePrivate(new PKCS8EncodedKeySpec(Hex.decode(
-                PRIVATE_KEY_HEX)));
-
-        assertThat(privateKey, equalTo(KeyUtils.privateKeyFromHexString(PRIVATE_KEY_HEX)));
+        PrivateKey privateKey = getKeyFactory().generatePrivate(new PKCS8EncodedKeySpec(PRIVATE_KEY.toArray()));
+        assertThat(privateKey, equalTo(KeyUtils.privateKeyFromHexString(PRIVATE_KEY)));
     }
 
     @Test
     public void testPublicKeyFromHexString() throws Exception {
-        PublicKey publicKey = getKeyFactory().generatePublic(new X509EncodedKeySpec((Hex.decode(
-                PUBLIC_KEY_HEX))));
-
-        assertThat(publicKey, equalTo(KeyUtils.publicKeyFromHexString(PUBLIC_KEY_HEX)));
+        PublicKey publicKey = getKeyFactory().generatePublic(new X509EncodedKeySpec(PUBLIC_KEY.toArray()));
+        assertThat(publicKey, equalTo(KeyUtils.publicKeyFromHexString(PUBLIC_KEY)));
     }
 
     private static KeyFactory getKeyFactory() throws Exception {

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/query/AccountResourceTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/query/AccountResourceTest.java
@@ -3,27 +3,25 @@ package dev.jlibra.admissioncontrol.query;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 
-import com.google.protobuf.ByteString;
-
+import dev.jlibra.serialization.ByteSequence;
 import types.AccountStateBlobOuterClass.AccountStateBlob;
 import types.AccountStateBlobOuterClass.AccountStateWithProof;
 
 public class AccountResourceTest {
 
-    private static final String ACCOUNT_DATA = "200000008f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5dc0c62d00000000000000030000000000000020000000e7753442710f04596279f6ea097c48782b0683e8b50071e8f2e34be523d7f2c5000000000000000020000000885ae34cf1f18d0c970b416afc7c5475f132511c5f3bbdce4af52ea09a0fd7030000000000000000";
+    private static final ByteSequence ACCOUNT_DATA = ByteSequence
+            .from("200000008f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5dc0c62d00000000000000030000000000000020000000e7753442710f04596279f6ea097c48782b0683e8b50071e8f2e34be523d7f2c5000000000000000020000000885ae34cf1f18d0c970b416afc7c5475f132511c5f3bbdce4af52ea09a0fd7030000000000000000");
 
-    private static final String ACCOUNT_STATE_BLOB = "01000000200000008f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5dc0c62d00000000000000030000000000000020000000e7753442710f04596279f6ea097c48782b0683e8b50071e8f2e34be523d7f2c5000000000000000020000000885ae34cf1f18d0c970b416afc7c5475f132511c5f3bbdce4af52ea09a0fd7030000000000000000";
+    private static final ByteSequence ACCOUNT_STATE_BLOB = ByteSequence
+            .from("010000008e000000200000008f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5dc0c62d00000000000000030000000000000020000000e7753442710f04596279f6ea097c48782b0683e8b50071e8f2e34be523d7f2c5000000000000000020000000885ae34cf1f18d0c970b416afc7c5475f132511c5f3bbdce4af52ea09a0fd7030000000000000000");
 
     @Test
     public void testDeserialize() {
-        byte[] accountDataBytes = Hex.decode(ACCOUNT_DATA);
+        AccountResource accountData = AccountResource.deserialize(ACCOUNT_DATA);
 
-        AccountResource accountData = AccountResource.deserialize(accountDataBytes);
-
-        assertThat(Hex.toHexString(accountData.getAuthenticationKey()),
+        assertThat(accountData.getAuthenticationKey().toString(),
                 is("8f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5d"));
         assertThat(accountData.getBalanceInMicroLibras(), is(3000000L));
         assertThat(accountData.getReceivedEvents().getCount(), is(3));
@@ -36,7 +34,7 @@ public class AccountResourceTest {
     @Test
     public void fromGrpcObject() {
         AccountStateWithProof accountStateWithProof = AccountStateWithProof.newBuilder()
-                .setBlob(AccountStateBlob.newBuilder().setBlob(ByteString.copyFrom(Hex.decode(ACCOUNT_STATE_BLOB))))
+                .setBlob(AccountStateBlob.newBuilder().setBlob(ACCOUNT_STATE_BLOB.toByteString()))
                 .build();
         assertThat(AccountResource.fromGrpcObject(accountStateWithProof).size(), is(1));
     }

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/query/EventTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/query/EventTest.java
@@ -3,24 +3,23 @@ package dev.jlibra.admissioncontrol.query;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 
-import com.google.protobuf.ByteString;
+import dev.jlibra.serialization.ByteSequence;
 
 public class EventTest {
 
-    private static String EVENT_DATA = "40420f00000000008f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5d";
+    private static ByteSequence EVENT_DATA = ByteSequence.from("40420f00000000008f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5d");
 
     @Test
     public void testFromGrpcObject() {
         types.Events.Event grpcEvent = types.Events.Event.newBuilder()
-                .setEventData(ByteString.copyFrom(Hex.decode(EVENT_DATA)))
+                .setEventData(EVENT_DATA.toByteString())
                 .setSequenceNumber(1L)
                 .build();
         Event event = Event.fromGrpcObject(grpcEvent);
 
-        assertThat(event.getAccountAddress().asHexString(),
+        assertThat(event.getAccountAddress().getByteSequence().toString(),
                 is("8f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5d"));
         assertThat(event.getAmount(), is(1000000L));
         assertThat(event.getSequenceNumber(), is(1L));

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/query/QueryTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/query/QueryTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.junit.Test;
 
 import dev.jlibra.AccountAddress;
+import dev.jlibra.serialization.ByteSequence;
 import types.GetWithProof.RequestItem;
 
 public class QueryTest {
@@ -23,40 +24,40 @@ public class QueryTest {
 
     @Test
     public void testAccountStateQueriesToRequestItems() {
-        byte[] address1 = new byte[] { 1 };
-        byte[] address2 = new byte[] { 2 };
+        ByteSequence address1 = ByteSequence.from(new byte[] { 1 });
+        ByteSequence address2 = ByteSequence.from(new byte[] { 2 });
 
         ImmutableQuery query = ImmutableQuery.builder()
                 .accountStateQueries(
                         asList(
                                 ImmutableGetAccountState.builder()
-                                        .address(AccountAddress.ofByteArray(address1))
+                                        .address(AccountAddress.ofByteSequence(address1))
                                         .build(),
                                 ImmutableGetAccountState.builder()
-                                        .address(AccountAddress.ofByteArray(address2))
+                                        .address(AccountAddress.ofByteSequence(address2))
                                         .build()))
                 .build();
 
         List<RequestItem> requestItems = query.toGrpcObject();
         assertThat(requestItems, hasSize(2));
-        assertThat(requestItems.get(0).getGetAccountStateRequest().getAddress().toByteArray(), is(address1));
-        assertThat(requestItems.get(1).getGetAccountStateRequest().getAddress().toByteArray(), is(address2));
+        assertThat(requestItems.get(0).getGetAccountStateRequest().getAddress().toByteArray(), is(address1.toArray()));
+        assertThat(requestItems.get(1).getGetAccountStateRequest().getAddress().toByteArray(), is(address2.toArray()));
     }
 
     @Test
     public void testAccountTransactionBySequenceNumberQueriesToRequestItems() {
-        byte[] address1 = new byte[] { 1 };
-        byte[] address2 = new byte[] { 2 };
+        ByteSequence address1 = ByteSequence.from(new byte[] { 1 });
+        ByteSequence address2 = ByteSequence.from(new byte[] { 2 });
 
         ImmutableQuery query = ImmutableQuery.builder()
                 .accountTransactionBySequenceNumberQueries(
                         asList(
                                 ImmutableGetAccountTransactionBySequenceNumber.builder()
-                                        .accountAddress(AccountAddress.ofByteArray(address1))
+                                        .accountAddress(AccountAddress.ofByteSequence(address1))
                                         .sequenceNumber(1)
                                         .build(),
                                 ImmutableGetAccountTransactionBySequenceNumber.builder()
-                                        .accountAddress(AccountAddress.ofByteArray(address2))
+                                        .accountAddress(AccountAddress.ofByteSequence(address2))
                                         .sequenceNumber(2)
                                         .build()))
                 .build();
@@ -65,10 +66,10 @@ public class QueryTest {
 
         assertThat(requestItems, hasSize(2));
         assertThat(requestItems.get(0).getGetAccountTransactionBySequenceNumberRequest().getAccount().toByteArray(),
-                is(address1));
+                is(address1.toArray()));
         assertThat(requestItems.get(0).getGetAccountTransactionBySequenceNumberRequest().getSequenceNumber(), is(1L));
         assertThat(requestItems.get(1).getGetAccountTransactionBySequenceNumberRequest().getAccount().toByteArray(),
-                is(address2));
+                is(address2.toArray()));
         assertThat(requestItems.get(1).getGetAccountTransactionBySequenceNumberRequest().getSequenceNumber(), is(2L));
     }
 }

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/query/UpdateToLatestLedgerResultTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/query/UpdateToLatestLedgerResultTest.java
@@ -1,17 +1,14 @@
 package dev.jlibra.admissioncontrol.query;
 
-import static org.bouncycastle.util.encoders.Hex.encode;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.Assert.assertThat;
 
 import java.util.List;
 
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 
-import com.google.protobuf.ByteString;
-
+import dev.jlibra.serialization.ByteSequence;
 import types.AccountStateBlobOuterClass.AccountStateBlob;
 import types.AccountStateBlobOuterClass.AccountStateWithProof;
 import types.GetWithProof.GetAccountStateResponse;
@@ -20,7 +17,8 @@ import types.GetWithProof.UpdateToLatestLedgerResponse;
 
 public class UpdateToLatestLedgerResultTest {
 
-    private static final String ACCOUNT_STATE_HEX = "010000002100000001217da6c6b3e19f1825cfb2676daecce3bf3de03cf26647c78df00b371b25cc978e000000200000008f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5dc0c62d00000000000000030000000000000020000000e7753442710f04596279f6ea097c48782b0683e8b50071e8f2e34be523d7f2c5000000000000000020000000885ae34cf1f18d0c970b416afc7c5475f132511c5f3bbdce4af52ea09a0fd7030000000000000000";
+    private static final ByteSequence ACCOUNT_STATE_BYTES = ByteSequence
+            .from("010000002100000001217da6c6b3e19f1825cfb2676daecce3bf3de03cf26647c78df00b371b25cc978e000000200000008f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5dc0c62d00000000000000030000000000000020000000e7753442710f04596279f6ea097c48782b0683e8b50071e8f2e34be523d7f2c5000000000000000020000000885ae34cf1f18d0c970b416afc7c5475f132511c5f3bbdce4af52ea09a0fd7030000000000000000");
 
     @Test
     public void testReadAccountStates() {
@@ -29,9 +27,7 @@ public class UpdateToLatestLedgerResultTest {
                         .setGetAccountStateResponse(GetAccountStateResponse.newBuilder()
                                 .setAccountStateWithProof(AccountStateWithProof.newBuilder().setBlob(
                                         AccountStateBlob.newBuilder()
-                                                .setBlob(ByteString
-                                                        .copyFrom(Hex
-                                                                .decode(ACCOUNT_STATE_HEX.getBytes())))
+                                                .setBlob(ACCOUNT_STATE_BYTES.toByteString())
                                                 .build()))
                                 .build()))
                 .build();
@@ -39,7 +35,7 @@ public class UpdateToLatestLedgerResultTest {
         List<AccountResource> accountStates = UpdateToLatestLedgerResult.fromGrpcObject(grpcResponse)
                 .getAccountResources();
         assertThat(accountStates, is(iterableWithSize(1)));
-        assertThat(new String(encode(accountStates.get(0).getAuthenticationKey())),
+        assertThat(accountStates.get(0).getAuthenticationKey().toString(),
                 is("8f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5d"));
         assertThat(accountStates.get(0).getBalanceInMicroLibras(), is(3000000L));
         assertThat(accountStates.get(0).getReceivedEvents().getCount(), is(3));

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/AccountAddressArgumentTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/AccountAddressArgumentTest.java
@@ -3,17 +3,17 @@ package dev.jlibra.admissioncontrol.transaction;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
+
+import dev.jlibra.serialization.ByteSequence;
 
 public class AccountAddressArgumentTest {
 
     @Test
     public void testSerialize() {
-        AccountAddressArgument argument = new AccountAddressArgument(
-                Hex.decode("2c25991785343b23ae073a50e5fd809a2cd867526b3c1db2b0bf5d1924c693ed"));
+        AccountAddressArgument argument = new AccountAddressArgument(ByteSequence.from("2c25991785343b23ae073a50e5fd809a2cd867526b3c1db2b0bf5d1924c693ed"));
 
-        assertThat(Hex.toHexString(argument.serialize()).toUpperCase(),
+        assertThat(argument.serialize().toString().toUpperCase(),
                 is("010000002C25991785343B23AE073A50E5FD809A2CD867526B3C1DB2B0BF5D1924C693ED"));
     }
 }

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/ScriptTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/ScriptTest.java
@@ -1,23 +1,21 @@
 package dev.jlibra.admissioncontrol.transaction;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
-import org.bouncycastle.util.encoders.Hex;
+import dev.jlibra.serialization.ByteSequence;
 import org.junit.Test;
 
-import com.google.protobuf.ByteString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class ScriptTest {
 
     @Test
     public void testSerialize() {
         Script program = ImmutableScript.builder()
-                .code(ByteString.copyFrom("move".getBytes()))
+                .code(ByteSequence.from("move".getBytes()))
                 .addArguments(new StringArgument("CAFE D00D"), new StringArgument("cafe d00d"))
                 .build();
 
-        assertThat(Hex.toHexString(program.serialize()).toUpperCase(), is(
+        assertThat(program.serialize().toString().toUpperCase(), is(
                 "02000000040000006D6F76650200000002000000090000004341464520443030440200000009000000636166652064303064"));
     }
 }

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/SignatureTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/SignatureTest.java
@@ -38,7 +38,7 @@ public class SignatureTest {
                         .build())
                 .build();
 
-        PrivateKey privateKey = KeyUtils.privateKeyFromHexString(PRIVATE_KEY_BYTES);
+        PrivateKey privateKey = KeyUtils.privateKeyFromByteSequence(PRIVATE_KEY_BYTES);
         Signature signature = ImmutableSignature.builder()
                 .privateKey(privateKey)
                 .transaction(transaction)

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/SignatureTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/SignatureTest.java
@@ -1,24 +1,22 @@
 package dev.jlibra.admissioncontrol.transaction;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.security.PrivateKey;
 import java.security.Security;
 
+import dev.jlibra.AccountAddress;
+import dev.jlibra.KeyUtils;
+import dev.jlibra.serialization.ByteSequence;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.protobuf.ByteString;
-
-import dev.jlibra.AccountAddress;
-import dev.jlibra.KeyUtils;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class SignatureTest {
 
-    private static final String PRIVATE_KEY_HEX = "3051020101300506032b6570042204206dadf7a252c0e74add2e545a1e3c811f1f4bdd88f8c5e0080e068f4df6d909128121000b29a7adce0897b2d1ec18cc482237463efa173945fa3bd2703023e1a2489021";
+    private static final ByteSequence PRIVATE_KEY_BYTES = ByteSequence
+            .from("3051020101300506032b6570042204206dadf7a252c0e74add2e545a1e3c811f1f4bdd88f8c5e0080e068f4df6d909128121000b29a7adce0897b2d1ec18cc482237463efa173945fa3bd2703023e1a2489021");
 
     @BeforeClass
     public static void setUpClass() {
@@ -33,22 +31,22 @@ public class SignatureTest {
                 .gasUnitPrice(3)
                 .sequenceNumber(4)
                 .expirationTime(5L)
-                .senderAccount(AccountAddress.ofByteArray(new byte[] { 1 }))
+                .senderAccount(AccountAddress.ofByteSequence(ByteSequence.from(new byte[] { 1 })))
                 .payload(ImmutableScript.builder()
-                        .addArguments(new U64Argument(1000), new AccountAddressArgument(new byte[] { 2 }))
-                        .code(ByteString.copyFrom(new byte[] { 3 }))
+                        .addArguments(new U64Argument(1000), new AccountAddressArgument(ByteSequence.from(new byte[] { 2 })))
+                        .code(ByteSequence.from(new byte[] { 3 }))
                         .build())
                 .build();
 
-        PrivateKey privateKey = KeyUtils.privateKeyFromHexString(PRIVATE_KEY_HEX);
+        PrivateKey privateKey = KeyUtils.privateKeyFromHexString(PRIVATE_KEY_BYTES);
         Signature signature = ImmutableSignature.builder()
                 .privateKey(privateKey)
                 .transaction(transaction)
                 .build();
 
-        assertThat(Hex.toHexString(signature.signTransaction(transaction, privateKey)), is(
+        assertThat(signature.signTransaction(transaction, privateKey).toString(), is(
                 "39856908d3c9accfa01e9403583a48c01b93c71600067d3422c7a3612ec213ff18355795e3e702ecd709f2361126cd14e573046c7fc3aec34ab3ea98be695a09"));
-        assertThat(Hex.toHexString(signature.serialize()), is(
+        assertThat(signature.serialize().toString(), is(
                 "4000000039856908d3c9accfa01e9403583a48c01b93c71600067d3422c7a3612ec213ff18355795e3e702ecd709f2361126cd14e573046c7fc3aec34ab3ea98be695a09"));
     }
 

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/SignedTransactionTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/SignedTransactionTest.java
@@ -40,9 +40,9 @@ public class SignedTransactionTest {
                 .build();
 
         SignedTransaction signedTransaction = ImmutableSignedTransaction.builder()
-                .publicKey(KeyUtils.publicKeyFromHexString(PUBLIC_KEY_HEX))
+                .publicKey(KeyUtils.publicKeyFromByteSequence(PUBLIC_KEY_HEX))
                 .signature(ImmutableSignature.builder()
-                        .privateKey(KeyUtils.privateKeyFromHexString(PRIVATE_KEY_HEX))
+                        .privateKey(KeyUtils.privateKeyFromByteSequence(PRIVATE_KEY_HEX))
                         .transaction(transaction)
                         .build())
                 .transaction(transaction)
@@ -68,9 +68,9 @@ public class SignedTransactionTest {
                 .build();
 
         SignedTransaction signedTransaction = ImmutableSignedTransaction.builder()
-                .publicKey(KeyUtils.publicKeyFromHexString(PUBLIC_KEY_HEX))
+                .publicKey(KeyUtils.publicKeyFromByteSequence(PUBLIC_KEY_HEX))
                 .signature(ImmutableSignature.builder()
-                        .privateKey(KeyUtils.privateKeyFromHexString(PRIVATE_KEY_HEX))
+                        .privateKey(KeyUtils.privateKeyFromByteSequence(PRIVATE_KEY_HEX))
                         .transaction(transaction)
                         .build())
                 .transaction(transaction)

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/SignedTransactionTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/SignedTransactionTest.java
@@ -1,24 +1,23 @@
 package dev.jlibra.admissioncontrol.transaction;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.security.Security;
 
+import admission_control.AdmissionControlOuterClass.SubmitTransactionRequest;
+import dev.jlibra.AccountAddress;
+import dev.jlibra.KeyUtils;
+import dev.jlibra.serialization.ByteSequence;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.google.protobuf.ByteString;
-
-import admission_control.AdmissionControlOuterClass.SubmitTransactionRequest;
-import dev.jlibra.AccountAddress;
-import dev.jlibra.KeyUtils;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class SignedTransactionTest {
-    private static final String PUBLIC_KEY_HEX = "302a300506032b65700321000b29a7adce0897b2d1ec18cc482237463efa173945fa3bd2703023e1a2489021";
-    private static final String PRIVATE_KEY_HEX = "3051020101300506032b6570042204206dadf7a252c0e74add2e545a1e3c811f1f4bdd88f8c5e0080e068f4df6d909128121000b29a7adce0897b2d1ec18cc482237463efa173945fa3bd2703023e1a2489021";
+    private static final ByteSequence PUBLIC_KEY_HEX = ByteSequence.from("302a300506032b65700321000b29a7adce0897b2d1ec18cc482237463efa173945fa3bd2703023e1a2489021");
+    private static final ByteSequence PRIVATE_KEY_HEX = ByteSequence
+        .from("3051020101300506032b6570042204206dadf7a252c0e74add2e545a1e3c811f1f4bdd88f8c5e0080e068f4df6d909128121000b29a7adce0897b2d1ec18cc482237463efa173945fa3bd2703023e1a2489021");
 
     @BeforeClass
     public static void setUpClass() {
@@ -33,10 +32,10 @@ public class SignedTransactionTest {
                 .gasUnitPrice(3)
                 .sequenceNumber(4)
                 .expirationTime(5L)
-                .senderAccount(AccountAddress.ofByteArray(new byte[] { 1 }))
+                .senderAccount(AccountAddress.ofByteSequence(ByteSequence.from(new byte[] { 1 })))
                 .payload(ImmutableScript.builder()
-                        .addArguments(new U64Argument(1000), new AccountAddressArgument(new byte[] { 2 }))
-                        .code(ByteString.copyFrom(new byte[] { 3 }))
+                        .addArguments(new U64Argument(1000), new AccountAddressArgument(ByteSequence.from(new byte[] { 2 })))
+                        .code(ByteSequence.from(new byte[] { 3 }))
                         .build())
                 .build();
 
@@ -49,22 +48,22 @@ public class SignedTransactionTest {
                 .transaction(transaction)
                 .build();
 
-        assertThat(Hex.toHexString(signedTransaction.serialize()).toUpperCase(), is(
+        assertThat(signedTransaction.serialize().toString().toUpperCase(), is(
                 "0104000000000000000200000001000000030200000000000000E8030000000000000100000002020000000000000003000000000000000500000000000000200000000B29A7ADCE0897B2D1EC18CC482237463EFA173945FA3BD2703023E1A24890214000000039856908D3C9ACCFA01E9403583A48C01B93C71600067D3422C7A3612EC213FF18355795E3E702ECD709F2361126CD14E573046C7FC3AEC34AB3EA98BE695A09"));
     }
 
     @Test
-    public void testToGrpcObject() throws Exception {
+    public void testToGrpcObject() {
         Transaction transaction = ImmutableTransaction.builder()
                 .expirationTime(10)
                 .maxGasAmount(6000)
                 .gasUnitPrice(1)
                 .sequenceNumber(1)
                 .expirationTime(1L)
-                .senderAccount(AccountAddress.ofByteArray(new byte[] { 1 }))
+                .senderAccount(AccountAddress.ofByteSequence(ByteSequence.from(new byte[] { 1 })))
                 .payload(ImmutableScript.builder()
-                        .addArguments(new U64Argument(1000), new AccountAddressArgument(new byte[] { 1 }))
-                        .code(ByteString.copyFrom(new byte[] { 1 }))
+                        .addArguments(new U64Argument(1000), new AccountAddressArgument(ByteSequence.from(new byte[] { 1 })))
+                        .code(ByteSequence.from(new byte[] { 1 }))
                         .build())
                 .build();
 

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/StringArgumentTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/StringArgumentTest.java
@@ -1,10 +1,9 @@
 package dev.jlibra.admissioncontrol.transaction;
 
+import org.junit.Test;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-
-import org.bouncycastle.util.encoders.Hex;
-import org.junit.Test;
 
 public class StringArgumentTest {
 
@@ -12,7 +11,7 @@ public class StringArgumentTest {
     public void testSerialize() {
         StringArgument argument = new StringArgument("Hello, World!");
 
-        assertThat(Hex.toHexString(argument.serialize()).toUpperCase(),
+        assertThat(argument.serialize().toString().toUpperCase(),
                 is("020000000D00000048656C6C6F2C20576F726C6421"));
     }
 }

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/TransactionTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/TransactionTest.java
@@ -1,14 +1,11 @@
 package dev.jlibra.admissioncontrol.transaction;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
-import org.bouncycastle.util.encoders.Hex;
+import dev.jlibra.AccountAddress;
+import dev.jlibra.serialization.ByteSequence;
 import org.junit.Test;
 
-import com.google.protobuf.ByteString;
-
-import dev.jlibra.AccountAddress;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class TransactionTest {
 
@@ -20,14 +17,14 @@ public class TransactionTest {
                 .gasUnitPrice(3)
                 .sequenceNumber(4)
                 .expirationTime(5L)
-                .senderAccount(AccountAddress.ofByteArray(new byte[] { 1 }))
+                .senderAccount(AccountAddress.ofByteSequence(ByteSequence.from(new byte[] { 1 })))
                 .payload(ImmutableScript.builder()
-                        .addArguments(new U64Argument(1000), new AccountAddressArgument(new byte[] { 2 }))
-                        .code(ByteString.copyFrom(new byte[] { 3 }))
+                        .addArguments(new U64Argument(1000), new AccountAddressArgument(ByteSequence.from(new byte[] { 2 })))
+                        .code(ByteSequence.from(new byte[] { 3 }))
                         .build())
                 .build();
 
-        assertThat(Hex.toHexString(transaction.serialize()).toUpperCase(), is(
+        assertThat(transaction.serialize().toString().toUpperCase(), is(
                 "0104000000000000000200000001000000030200000000000000E8030000000000000100000002020000000000000003000000000000000500000000000000"));
     }
 

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/U64ArgumentTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/U64ArgumentTest.java
@@ -1,10 +1,9 @@
 package dev.jlibra.admissioncontrol.transaction;
 
+import org.junit.Test;
+
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-
-import org.bouncycastle.util.encoders.Hex;
-import org.junit.Test;
 
 public class U64ArgumentTest {
 
@@ -12,7 +11,7 @@ public class U64ArgumentTest {
     public void testSerialize() {
         U64Argument argument = new U64Argument(9213671392124193148L);
 
-        assertThat(Hex.toHexString(argument.serialize()).toUpperCase(),
+        assertThat(argument.serialize().toString().toUpperCase(),
                 is("000000007CC9BDA45089DD7F"));
     }
 }

--- a/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/result/SubmitTransactionResultTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/admissioncontrol/transaction/result/SubmitTransactionResultTest.java
@@ -1,20 +1,18 @@
 package dev.jlibra.admissioncontrol.transaction.result;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import com.google.protobuf.ByteString;
-
 import admission_control.AdmissionControlOuterClass.AdmissionControlStatus;
 import admission_control.AdmissionControlOuterClass.AdmissionControlStatusCode;
 import admission_control.AdmissionControlOuterClass.SubmitTransactionResponse;
+import dev.jlibra.serialization.ByteSequence;
 import mempool_status.MempoolStatus.MempoolAddTransactionStatus;
 import mempool_status.MempoolStatus.MempoolAddTransactionStatusCode;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import types.VmErrors.VMStatus;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class SubmitTransactionResultTest {
 
@@ -23,12 +21,12 @@ public class SubmitTransactionResultTest {
 
     @Test
     public void testAdmissionControlAccepted() throws Exception {
-        byte[] validatorId = new byte[] { 1 };
+        ByteSequence validatorId = ByteSequence.from(new byte[] { 1 });
         SubmitTransactionResponse response = SubmitTransactionResponse.newBuilder()
                 .setAcStatus(AdmissionControlStatus.newBuilder()
                         .setCode(AdmissionControlStatusCode.Accepted)
                         .build())
-                .setValidatorId(ByteString.copyFrom(validatorId))
+                .setValidatorId(validatorId.toByteString())
                 .build();
 
         SubmitTransactionResult result = SubmitTransactionResult.fromGrpcObject(response);

--- a/jlibra-core/src/test/java/dev/jlibra/mnemonic/ExtendedPrivKeyTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/mnemonic/ExtendedPrivKeyTest.java
@@ -2,15 +2,15 @@ package dev.jlibra.mnemonic;
 
 import static org.junit.Assert.assertEquals;
 
+import java.security.Security;
+
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.util.encoders.Hex;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.security.Security;
-
 import dev.jlibra.KeyUtils;
+import dev.jlibra.serialization.ByteSequence;
 
 /**
  * Test data and mnemonic seed generated using libra cli.
@@ -44,7 +44,7 @@ public class ExtendedPrivKeyTest {
     public void getPublic() {
         assertEquals(
                 "be10d382d1f3de00c19607f667b5b127da22f42f0a3a4b70eaef690365421511",
-                Hex.toHexString(KeyUtils.stripPublicKeyPrefix(childPrivate0.publicKey.getEncoded())));
+                KeyUtils.stripPublicKeyPrefix(ByteSequence.from(childPrivate0.publicKey.getEncoded())).toString());
     }
 
 }

--- a/jlibra-core/src/test/java/dev/jlibra/mnemonic/MnemonicTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/mnemonic/MnemonicTest.java
@@ -1,6 +1,6 @@
 package dev.jlibra.mnemonic;
 
-import org.bouncycastle.util.encoders.Hex;
+import dev.jlibra.serialization.ByteSequence;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -9,12 +9,11 @@ public class MnemonicTest {
 
     @Test
     public void fromSeed() {
-        // test data from https://github.com/libra/libra/blob/master/client/libra_wallet/src/key_factory.rs
-        byte[] data = Hex.decode("7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f");
+        ByteSequence byteSequence = ByteSequence.from("7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f");
         Mnemonic mnemonic = Mnemonic.fromString("legal winner thank year wave sausage worth useful legal winner thank year wave sausage worth useful legal will");
         assertEquals(
                 mnemonic.toString(),
-                Mnemonic.fromBytes(data).toString()
+                Mnemonic.fromByteSequence(byteSequence).toString()
         );
     }
 }

--- a/jlibra-core/src/test/java/dev/jlibra/serialization/SerializerTest.java
+++ b/jlibra-core/src/test/java/dev/jlibra/serialization/SerializerTest.java
@@ -1,55 +1,52 @@
 package dev.jlibra.serialization;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import java.util.Arrays;
 import java.util.List;
 
-import org.bouncycastle.util.encoders.Hex;
-import org.junit.Test;
-
 import dev.jlibra.admissioncontrol.transaction.TransactionArgument;
 import dev.jlibra.admissioncontrol.transaction.U64Argument;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 public class SerializerTest {
 
     @Test
     public void testSerializeInt() {
-        assertThat(Hex.toHexString(Serializer.builder().appendInt(32).toByteArray()), is("20000000"));
-        assertThat(Hex.toHexString(Serializer.builder().appendInt(305419896).toByteArray()), is("78563412"));
-        assertThat(Hex.toHexString(Serializer.builder().appendInt(32).appendInt(305419896).toByteArray()),
+        assertThat(Serializer.builder().appendInt(32).toByteSequence().toString(), is("20000000"));
+        assertThat(Serializer.builder().appendInt(305419896).toByteSequence().toString(), is("78563412"));
+        assertThat(Serializer.builder().appendInt(32).appendInt(305419896).toByteSequence().toString(),
                 is("2000000078563412"));
     }
 
     @Test
     public void testSerializeLong() {
-        assertThat(Hex.toHexString(Serializer.builder().appendLong(1311768467750121216L).toByteArray()).toUpperCase(),
+        assertThat(Serializer.builder().appendLong(1311768467750121216L).toByteSequence().toString().toUpperCase(),
                 is("00EFCDAB78563412"));
     }
 
     @Test
     public void testSerializeString() {
         assertThat(
-                Hex.toHexString(Serializer.builder().appendString("ሰማይ አይታረስ ንጉሥ አይከሰስ።").toByteArray()).toUpperCase(),
+                Serializer.builder().appendString("ሰማይ አይታረስ ንጉሥ አይከሰስ።").toByteSequence().toString().toUpperCase(),
                 is("36000000E188B0E1889BE18BAD20E18AA0E18BADE189B3E188A8E188B520E18A95E18C89E188A520E18AA0E18BADE18AA8E188B0E188B5E18DA2"));
     }
 
     @Test
-    public void testSerializeByteArray() {
-        byte[] byteArray = Hex.decode("ca820bf9305eb97d0d784f71b3955457fbf6911f5300ceaa5d7e8621529eae19");
+    public void testSerializeByteSequence() {
+        ByteSequence byteSequence = ByteSequence.from("ca820bf9305eb97d0d784f71b3955457fbf6911f5300ceaa5d7e8621529eae19");
 
-        assertThat(Hex.toHexString(Serializer.builder().appendByteArray(byteArray).toByteArray()).toUpperCase(),
+        assertThat(Serializer.builder().append(byteSequence).toByteSequence().toString().toUpperCase(),
                 is("20000000CA820BF9305EB97D0D784F71B3955457FBF6911F5300CEAA5D7E8621529EAE19"));
     }
 
     @Test
-    public void testSerializeByteArrayWithoutLengthInformation() {
-        byte[] byteArray = Hex.decode("ca820bf9305eb97d0d784f71b3955457fbf6911f5300ceaa5d7e8621529eae19");
+    public void testSerializeByteSequenceWithoutLengthInformation() {
+        ByteSequence byteSequence = ByteSequence.from("ca820bf9305eb97d0d784f71b3955457fbf6911f5300ceaa5d7e8621529eae19");
 
         assertThat(
-                Hex.toHexString(Serializer.builder().appendByteArrayWithoutLengthInformation(byteArray).toByteArray())
-                        .toUpperCase(),
+                Serializer.builder().appendWithoutLengthInformation(byteSequence).toByteSequence().toString().toUpperCase(),
                 is("CA820BF9305EB97D0D784F71B3955457FBF6911F5300CEAA5D7E8621529EAE19"));
     }
 
@@ -58,7 +55,7 @@ public class SerializerTest {
         List<TransactionArgument> arguments = Arrays.asList(new U64Argument(9213671392124193148L));
 
         assertThat(
-                Hex.toHexString(Serializer.builder().appendTransactionArguments(arguments).toByteArray()).toUpperCase(),
+                Serializer.builder().appendTransactionArguments(arguments).toByteSequence().toString().toUpperCase(),
                 is("01000000000000007CC9BDA45089DD7F"));
     }
 }

--- a/jlibra-examples/src/main/java/dev/jlibra/example/GenerateKeysExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/GenerateKeysExample.java
@@ -9,9 +9,9 @@ import org.apache.logging.log4j.Logger;
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey;
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.util.encoders.Hex;
 
 import dev.jlibra.AccountAddress;
+import dev.jlibra.serialization.ByteSequence;
 
 public class GenerateKeysExample {
 
@@ -29,8 +29,8 @@ public class GenerateKeysExample {
         BCEdDSAPublicKey publicKey = (BCEdDSAPublicKey) keyPair.getPublic();
 
         logger.info("Libra address: {}", AccountAddress.ofPublicKey(publicKey));
-        logger.info("Public key: {}", Hex.toHexString(publicKey.getEncoded()));
-        logger.info("Private key: {}", Hex.toHexString(privateKey.getEncoded()));
+        logger.info("Public key: {}", ByteSequence.from(publicKey.getEncoded()));
+        logger.info("Private key: {}", ByteSequence.from(privateKey.getEncoded()));
     }
 
 }

--- a/jlibra-examples/src/main/java/dev/jlibra/example/GetAccountStateExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/GetAccountStateExample.java
@@ -6,13 +6,13 @@ import java.math.BigDecimal;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bouncycastle.util.encoders.Hex;
 
 import dev.jlibra.AccountAddress;
 import dev.jlibra.admissioncontrol.AdmissionControl;
 import dev.jlibra.admissioncontrol.query.ImmutableGetAccountState;
 import dev.jlibra.admissioncontrol.query.ImmutableQuery;
 import dev.jlibra.admissioncontrol.query.UpdateToLatestLedgerResult;
+import dev.jlibra.serialization.ByteSequence;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
@@ -34,12 +34,12 @@ public class GetAccountStateExample {
                         ImmutableQuery.builder()
                                 .accountStateQueries(asList(
                                         ImmutableGetAccountState.builder()
-                                                .address(AccountAddress.ofHexString(address))
+                                                .address(AccountAddress.ofByteSequence(ByteSequence.from(address)))
                                                 .build()))
                                 .build());
 
         result.getAccountResources().forEach(accountResource -> {
-            logger.info("Authentication key: {}", Hex.toHexString(accountResource.getAuthenticationKey()));
+            logger.info("Authentication key: {}", accountResource.getAuthenticationKey());
             logger.info("Received events: {}", accountResource.getReceivedEvents().getCount());
             logger.info("Sent events: {}", accountResource.getSentEvents().getCount());
             logger.info("Balance (microLibras): {}", accountResource.getBalanceInMicroLibras());

--- a/jlibra-examples/src/main/java/dev/jlibra/example/GetAccountTransactionBySequenceNumberExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/GetAccountTransactionBySequenceNumberExample.java
@@ -10,6 +10,7 @@ import dev.jlibra.admissioncontrol.AdmissionControl;
 import dev.jlibra.admissioncontrol.query.ImmutableGetAccountTransactionBySequenceNumber;
 import dev.jlibra.admissioncontrol.query.ImmutableQuery;
 import dev.jlibra.admissioncontrol.query.UpdateToLatestLedgerResult;
+import dev.jlibra.serialization.ByteSequence;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 
@@ -30,14 +31,14 @@ public class GetAccountTransactionBySequenceNumberExample {
         UpdateToLatestLedgerResult result = admissionControl.updateToLatestLedger(ImmutableQuery.builder()
                 .accountTransactionBySequenceNumberQueries(
                         asList(ImmutableGetAccountTransactionBySequenceNumber.builder()
-                                .accountAddress(AccountAddress.ofHexString(address))
+                                .accountAddress(AccountAddress.ofByteSequence(ByteSequence.from(address)))
                                 .sequenceNumber(sequenceNumber)
                                 .build()))
                 .build());
 
         result.getAccountTransactionsBySequenceNumber().forEach(tx -> tx.getEvents()
                 .forEach(e -> logger.info("{}: Sequence number: {}, Amount: {}",
-                        e.getAccountAddress().asHexString(), e.getSequenceNumber(), e.getAmount())));
+                        e.getAccountAddress(), e.getSequenceNumber(), e.getAmount())));
 
         channel.shutdown();
     }

--- a/jlibra-examples/src/main/java/dev/jlibra/example/KeyRotationExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/KeyRotationExample.java
@@ -187,7 +187,7 @@ public class KeyRotationExample {
     private static void mint(AccountAddress address, long amountInMicroLibras) {
         HttpResponse<String> response = Unirest.post("http://faucet.testnet.libra.org")
                 .queryString("amount", amountInMicroLibras)
-                .queryString("address", address.toString())
+                .queryString("address", address.getByteSequence().toString())
                 .asString();
 
         if (response.getStatus() != 200) {

--- a/jlibra-examples/src/main/java/dev/jlibra/example/TransferExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/TransferExample.java
@@ -31,9 +31,9 @@ public class TransferExample {
     public static void main(String[] args) throws Exception {
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 
-        PrivateKey privateKey = KeyUtils.privateKeyFromHexString(ByteSequence.from(
+        PrivateKey privateKey = KeyUtils.privateKeyFromByteSequence(ByteSequence.from(
                 "3051020101300506032b657004220420c18abb47a0577c71e50f408214df5bfec3a0969d361170023084c6c6ae295ab88121000e17c9353c32509613b43bb66aa4242ca9277445d526c98d71add83bc2751d13"));
-        PublicKey publicKey = KeyUtils.publicKeyFromHexString(ByteSequence.from(
+        PublicKey publicKey = KeyUtils.publicKeyFromByteSequence(ByteSequence.from(
                 "302a300506032b65700321000e17c9353c32509613b43bb66aa4242ca9277445d526c98d71add83bc2751d13"));
 
         String toAddress = "8f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5d";

--- a/jlibra-examples/src/main/java/dev/jlibra/example/TransferExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/TransferExample.java
@@ -1,17 +1,9 @@
 package dev.jlibra.example;
 
-import static dev.jlibra.KeyUtils.toHexStringLibraAddress;
-
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Security;
 import java.time.Instant;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.bouncycastle.util.encoders.Hex;
-
-import com.google.protobuf.ByteString;
 
 import dev.jlibra.AccountAddress;
 import dev.jlibra.KeyUtils;
@@ -26,8 +18,11 @@ import dev.jlibra.admissioncontrol.transaction.Transaction;
 import dev.jlibra.admissioncontrol.transaction.U64Argument;
 import dev.jlibra.admissioncontrol.transaction.result.SubmitTransactionResult;
 import dev.jlibra.move.Move;
+import dev.jlibra.serialization.ByteSequence;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TransferExample {
 
@@ -36,17 +31,17 @@ public class TransferExample {
     public static void main(String[] args) throws Exception {
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 
-        PrivateKey privateKey = KeyUtils.privateKeyFromHexString(
-                "3051020101300506032b657004220420c18abb47a0577c71e50f408214df5bfec3a0969d361170023084c6c6ae295ab88121000e17c9353c32509613b43bb66aa4242ca9277445d526c98d71add83bc2751d13");
-        PublicKey publicKey = KeyUtils.publicKeyFromHexString(
-                "302a300506032b65700321000e17c9353c32509613b43bb66aa4242ca9277445d526c98d71add83bc2751d13");
+        PrivateKey privateKey = KeyUtils.privateKeyFromHexString(ByteSequence.from(
+                "3051020101300506032b657004220420c18abb47a0577c71e50f408214df5bfec3a0969d361170023084c6c6ae295ab88121000e17c9353c32509613b43bb66aa4242ca9277445d526c98d71add83bc2751d13"));
+        PublicKey publicKey = KeyUtils.publicKeyFromHexString(ByteSequence.from(
+                "302a300506032b65700321000e17c9353c32509613b43bb66aa4242ca9277445d526c98d71add83bc2751d13"));
 
         String toAddress = "8f5fbb9486acc5fb90f1a6be43a0013d4a7f7f06e3d5fe995be1e9b272c09b5d";
 
         long amount = 1;
         int sequenceNumber = 2;
 
-        logger.info("Sending from {} to {}", toHexStringLibraAddress(publicKey.getEncoded()), toAddress);
+        logger.info("Sending from {} to {}", ByteSequence.from(publicKey.getEncoded()), toAddress);
 
         ManagedChannel channel = ManagedChannelBuilder.forAddress("ac.testnet.libra.org", 8000)
                 .usePlaintext()
@@ -56,7 +51,7 @@ public class TransferExample {
 
         // Arguments for the peer to peer transaction
         U64Argument amountArgument = new U64Argument(amount * 1000000);
-        AccountAddressArgument addressArgument = new AccountAddressArgument(Hex.decode(toAddress));
+        AccountAddressArgument addressArgument = new AccountAddressArgument(ByteSequence.from(toAddress));
 
         Transaction transaction = ImmutableTransaction.builder()
                 .sequenceNumber(sequenceNumber)
@@ -65,7 +60,7 @@ public class TransferExample {
                 .senderAccount(AccountAddress.ofPublicKey(publicKey))
                 .expirationTime(Instant.now().getEpochSecond() + 60)
                 .payload(ImmutableScript.builder()
-                        .code(ByteString.copyFrom(Move.peerToPeerTransferAsBytes()))
+                        .code(Move.peerToPeerTransferAsBytes())
                         .addArguments(addressArgument, amountArgument)
                         .build())
                 .build();
@@ -81,7 +76,7 @@ public class TransferExample {
 
         SubmitTransactionResult result = admissionControl.submitTransaction(signedTransaction);
 
-        logger.info("Result: " + result);
+        logger.info("Result: {}", result);
         Thread.sleep(3000); // add sleep to prevent premature closing of channel
         channel.shutdown();
     }


### PR DESCRIPTION
I've designed a replacement for `byte[]` called `ByteSequence`. Naming options are quite limited because there are similar classes within jlibra dependencies and standard library called `ByteBuffer`, `ByteString` and more, so wanted to find an unique name for this new wrapper.

It is immutable does Hex'ing and de'Hexing and also can make `ByteString` instances, which is useful when working with grpc.

Removed all (I think) usages of `byte[]` from `public` methods. Left some `byte[]` usages where it is encapsulated within scope of the same method or privately in a class. I think all interfaces now use `ByteSequence` instead.

