### PR TITLE
Use pollers instead of Thread.sleep in examples

### DIFF
--- a/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/AccountResource.java
+++ b/jlibra-core/src/main/java/dev/jlibra/admissioncontrol/query/AccountResource.java
@@ -14,13 +14,14 @@ import java.util.List;
 import org.immutables.value.Value;
 
 import dev.jlibra.LibraRuntimeException;
+import dev.jlibra.serialization.ByteArray;
 import dev.jlibra.serialization.ByteSequence;
 import types.AccountStateBlobOuterClass.AccountStateWithProof;
 
 @Value.Immutable
 public interface AccountResource {
 
-    ByteSequence getAuthenticationKey();
+    ByteArray getAuthenticationKey();
 
     long getBalanceInMicroLibras();
 
@@ -38,7 +39,7 @@ public interface AccountResource {
         try (DataInputStream accountDataStream = new DataInputStream(
                 new ByteArrayInputStream(byteSequence.toArray()))) {
             int addressLength = readInt(accountDataStream, 4);
-            ByteSequence address = readByteArray(accountDataStream, addressLength);
+            ByteArray address = readByteArray(accountDataStream, addressLength);
             long balance = readLong(accountDataStream, 8);
             boolean delegatedKeyRotationCapability = readBoolean(accountDataStream);
             boolean delegatedWithdrawalCapability = readBoolean(accountDataStream);

--- a/jlibra-examples/pom.xml
+++ b/jlibra-examples/pom.xml
@@ -30,6 +30,11 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.jodah</groupId>
+      <artifactId>failsafe</artifactId>
+      <version>2.3.3</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jlibra-examples/src/main/java/dev/jlibra/example/GetEventsByEventAccessPathExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/GetEventsByEventAccessPathExample.java
@@ -44,7 +44,6 @@ public class GetEventsByEventAccessPathExample {
         });
 
         channel.shutdown();
-
     }
 
 }

--- a/jlibra-examples/src/main/java/dev/jlibra/example/util/ExampleUtils.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/util/ExampleUtils.java
@@ -1,4 +1,4 @@
-package dev.jlibra.example;
+package dev.jlibra.example.util;
 
 import static java.lang.String.format;
 

--- a/jlibra-examples/src/main/java/dev/jlibra/example/wait/Wait.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/wait/Wait.java
@@ -1,0 +1,28 @@
+package dev.jlibra.example.wait;
+
+import java.time.Duration;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import dev.jlibra.example.wait.condition.WaitCondition;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+
+public class Wait {
+
+    private static final Logger logger = LogManager.getLogger(Wait.class);
+
+    public static void until(WaitCondition waitCondition) {
+        RetryPolicy<Boolean> retryPolicy = new RetryPolicy<Boolean>()
+                .onFailedAttempt(
+                        e -> logger.info("Condition was not met. Retrying..", e.getLastFailure()))
+                .withDelay(Duration.ofMillis(1000))
+                .withMaxRetries(5)
+                .withMaxDuration(Duration.ofSeconds(10))
+                .handleResult(Boolean.FALSE);
+
+        Failsafe.with(retryPolicy).get(() -> waitCondition.isFulfilled());
+    }
+
+}

--- a/jlibra-examples/src/main/java/dev/jlibra/example/wait/condition/Account.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/wait/condition/Account.java
@@ -1,0 +1,51 @@
+package dev.jlibra.example.wait.condition;
+
+import static java.util.Arrays.asList;
+
+import dev.jlibra.AccountAddress;
+import dev.jlibra.admissioncontrol.AdmissionControl;
+import dev.jlibra.admissioncontrol.query.ImmutableGetAccountState;
+import dev.jlibra.admissioncontrol.query.ImmutableQuery;
+import dev.jlibra.admissioncontrol.query.UpdateToLatestLedgerResult;
+import dev.jlibra.serialization.ByteArray;
+
+public class Account {
+
+    public static WaitCondition exists(AdmissionControl admissionControl, AccountAddress accountAddress) {
+        return () -> {
+            UpdateToLatestLedgerResult result = admissionControl.updateToLatestLedger(ImmutableQuery.builder()
+                    .accountStateQueries(asList(ImmutableGetAccountState.builder()
+                            .address(accountAddress)
+                            .build()))
+                    .build());
+            return Boolean.valueOf(!result.getAccountStateQueryResults().isEmpty());
+        };
+    }
+
+    public static WaitCondition containsAtLeast(long amountOfLibra, AccountAddress address,
+            AdmissionControl admissionControl) {
+        return () -> {
+            UpdateToLatestLedgerResult result = admissionControl.updateToLatestLedger(ImmutableQuery.builder()
+                    .accountStateQueries(asList(ImmutableGetAccountState.builder()
+                            .address(address)
+                            .build()))
+                    .build());
+            return Boolean.valueOf(!result.getAccountStateQueryResults().isEmpty() && result
+                    .getAccountStateQueryResults().get(0).getBalanceInMicroLibras() > amountOfLibra * 1_000_000);
+        };
+    }
+
+    public static WaitCondition authenticationKeyEquals(ByteArray authenticationKey, AccountAddress address,
+            AdmissionControl admissionControl) {
+        return () -> {
+            UpdateToLatestLedgerResult result = admissionControl.updateToLatestLedger(ImmutableQuery.builder()
+                    .accountStateQueries(asList(ImmutableGetAccountState.builder()
+                            .address(address)
+                            .build()))
+                    .build());
+            return Boolean.valueOf(!result.getAccountStateQueryResults().isEmpty() && result
+                    .getAccountStateQueryResults().get(0).getAuthenticationKey().equals(authenticationKey));
+        };
+    }
+
+}

--- a/jlibra-examples/src/main/java/dev/jlibra/example/wait/condition/Transactions.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/wait/condition/Transactions.java
@@ -1,0 +1,29 @@
+package dev.jlibra.example.wait.condition;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+
+import dev.jlibra.admissioncontrol.AdmissionControl;
+import dev.jlibra.admissioncontrol.query.ImmutableGetAccountTransactionBySequenceNumber;
+import dev.jlibra.admissioncontrol.query.ImmutableQuery;
+import dev.jlibra.admissioncontrol.query.UpdateToLatestLedgerResult;
+import dev.jlibra.admissioncontrol.transaction.Transaction;
+
+public class Transactions {
+    public static WaitCondition executed(List<Transaction> transactions, AdmissionControl admissionControl) {
+        return () -> {
+            UpdateToLatestLedgerResult result = admissionControl
+                    .updateToLatestLedger(ImmutableQuery.builder()
+                            .accountTransactionBySequenceNumberQueries(transactions.stream()
+                                    .map(t -> ImmutableGetAccountTransactionBySequenceNumber.builder()
+                                            .accountAddress(t.getSenderAccount())
+                                            .sequenceNumber(t.getSequenceNumber())
+                                            .fetchEvents(false)
+                                            .build())
+                                    .collect(toList()))
+                            .build());
+            return result.getAccountTransactionBySequenceNumberQueryResults().size() == transactions.size();
+        };
+    }
+}

--- a/jlibra-examples/src/main/java/dev/jlibra/example/wait/condition/WaitCondition.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/wait/condition/WaitCondition.java
@@ -1,0 +1,6 @@
+package dev.jlibra.example.wait.condition;
+
+public interface WaitCondition {
+
+    boolean isFulfilled();
+}


### PR DESCRIPTION
- I thought about using awaitility (the tool used in integration tests) but I understood it's meant more for testing so I decided to use Failsafe for this. And the new dependency should not be a problem as this is only in the examples module.
- There is still a couple of sleep -methods called at the end of the example method. But those are related to the problem @ice09 had a long time ago, that the channel was closing before the transaction was sent, I'm not sure if this is still an issue
- If you have ideas how the interface for the polling can be improved, I open for suggestions, this is just something I came up now.

fixes #84