### PR TITLE
slf4j + workaround simple-json-rpc bug

### DIFF
--- a/jlibra-core/pom.xml
+++ b/jlibra-core/pom.xml
@@ -36,6 +36,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.12</version>

--- a/jlibra-examples/pom.xml
+++ b/jlibra-examples/pom.xml
@@ -24,11 +24,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
     <dependency>
       <groupId>net.jodah</groupId>

--- a/jlibra-examples/src/main/java/dev/jlibra/example/GenerateKeysExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/GenerateKeysExample.java
@@ -4,11 +4,11 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.Security;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey;
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.jlibra.AccountAddress;
 import dev.jlibra.AuthenticationKey;
@@ -16,7 +16,7 @@ import dev.jlibra.serialization.ByteArray;
 
 public class GenerateKeysExample {
 
-    private static final Logger logger = LogManager.getLogger(GenerateKeysExample.class);
+    private static final Logger logger = LoggerFactory.getLogger(GenerateKeysExample.class);
 
     public static void main(String[] args) throws Exception {
         Security.addProvider(new BouncyCastleProvider());

--- a/jlibra-examples/src/main/java/dev/jlibra/example/GetAccountStateExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/GetAccountStateExample.java
@@ -2,8 +2,8 @@ package dev.jlibra.example;
 
 import java.math.BigDecimal;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.jlibra.AccountAddress;
 import dev.jlibra.client.LibraClient;
@@ -11,10 +11,10 @@ import dev.jlibra.client.views.Account;
 
 public class GetAccountStateExample {
 
-    private static final Logger logger = LogManager.getLogger(GetAccountStateExample.class);
+    private static final Logger logger = LoggerFactory.getLogger(GetAccountStateExample.class);
 
     public static void main(String[] args) throws Exception {
-        String address = "2ab3189806488e73014e2e429e45c143";
+        String address = "8a0461f91654bb308638907907e348cc";
 
         LibraClient client = LibraClient.builder()
                 .withUrl("http://client.testnet.libra.org/")

--- a/jlibra-examples/src/main/java/dev/jlibra/example/GetAccountTransactionBySequenceNumberExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/GetAccountTransactionBySequenceNumberExample.java
@@ -1,7 +1,7 @@
 package dev.jlibra.example;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.jlibra.AccountAddress;
 import dev.jlibra.client.LibraClient;
@@ -9,7 +9,7 @@ import dev.jlibra.client.views.Transaction;
 
 public class GetAccountTransactionBySequenceNumberExample {
 
-    private static final Logger logger = LogManager.getLogger(GetAccountTransactionBySequenceNumberExample.class);
+    private static final Logger logger = LoggerFactory.getLogger(GetAccountTransactionBySequenceNumberExample.class);
 
     public static void main(String[] args) {
         String address = "4fa2be7ad55936c5702e8b7e3fdedb05";
@@ -21,6 +21,6 @@ public class GetAccountTransactionBySequenceNumberExample {
 
         Transaction t = client.getAccountTransaction(AccountAddress.fromHexString(address), sequenceNumber, true);
 
-        logger.info(t);
+        logger.info("Transaction: {}", t);
     }
 }

--- a/jlibra-examples/src/main/java/dev/jlibra/example/GetEventsByEventKeyExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/GetEventsByEventKeyExample.java
@@ -2,14 +2,15 @@ package dev.jlibra.example;
 
 import java.util.List;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.jlibra.client.LibraClient;
 import dev.jlibra.client.views.Event;
 
 public class GetEventsByEventKeyExample {
-    private static final Logger logger = LogManager.getLogger(GetEventsByEventKeyExample.class);
+
+    private static final Logger logger = LoggerFactory.getLogger(GetEventsByEventKeyExample.class);
 
     public static void main(String[] args) {
         String eventKey = "0000000000000000b3f7e8e38f8c8393f281a2f0792a2849";
@@ -20,7 +21,7 @@ public class GetEventsByEventKeyExample {
 
         List<Event> events = client.getEvents(eventKey, 0, 10);
 
-        events.forEach(logger::info);
+        events.forEach(e -> logger.info("Event: {}", e));
     }
 
 }

--- a/jlibra-examples/src/main/java/dev/jlibra/example/GetStateProofExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/GetStateProofExample.java
@@ -1,13 +1,13 @@
 package dev.jlibra.example;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.jlibra.client.LibraClient;
 import dev.jlibra.client.views.StateProof;
 
 public class GetStateProofExample {
-    private static final Logger logger = LogManager.getLogger(GetStateProofExample.class);
+    private static final Logger logger = LoggerFactory.getLogger(GetStateProofExample.class);
 
     public static void main(String[] args) {
         LibraClient client = LibraClient.builder()
@@ -16,7 +16,7 @@ public class GetStateProofExample {
 
         StateProof stateProof = client.getStateProof(11252608);
 
-        logger.info(stateProof);
+        logger.info("State proof: {}", stateProof);
     }
 
 }

--- a/jlibra-examples/src/main/java/dev/jlibra/example/GetTransactionsExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/GetTransactionsExample.java
@@ -2,8 +2,8 @@ package dev.jlibra.example;
 
 import java.util.List;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.jlibra.client.LibraClient;
 import dev.jlibra.client.views.Transaction;
@@ -16,7 +16,7 @@ import dev.jlibra.client.views.Transaction;
  */
 public class GetTransactionsExample {
 
-    private static final Logger logger = LogManager.getLogger(GetTransactionsExample.class);
+    private static final Logger logger = LoggerFactory.getLogger(GetTransactionsExample.class);
 
     public static void main(String[] args) {
         long start = 15134650;
@@ -30,7 +30,7 @@ public class GetTransactionsExample {
         List<Transaction> transactions = client.getTransactions(start, limit, fetchEvent);
 
         transactions.forEach(t -> {
-            logger.info(t);
+            logger.info("Transaction: {}", t);
         });
     }
 }

--- a/jlibra-examples/src/main/java/dev/jlibra/example/ImportAccountMnemonicExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/ImportAccountMnemonicExample.java
@@ -2,9 +2,9 @@ package dev.jlibra.example;
 
 import java.security.Security;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.jlibra.mnemonic.ChildNumber;
 import dev.jlibra.mnemonic.ExtendedPrivKey;
@@ -14,7 +14,7 @@ import dev.jlibra.mnemonic.Seed;
 
 public class ImportAccountMnemonicExample {
 
-    private static final Logger logger = LogManager.getLogger(ImportAccountMnemonicExample.class);
+    private static final Logger logger = LoggerFactory.getLogger(ImportAccountMnemonicExample.class);
 
     public static void main(String[] args) {
         Security.addProvider(new BouncyCastleProvider());

--- a/jlibra-examples/src/main/java/dev/jlibra/example/KeyRotationExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/KeyRotationExample.java
@@ -10,10 +10,10 @@ import java.security.Security;
 import java.time.Instant;
 import java.util.ArrayList;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey;
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.jlibra.AccountAddress;
 import dev.jlibra.AuthenticationKey;
@@ -34,7 +34,7 @@ import dev.jlibra.poller.Wait;
 
 public class KeyRotationExample {
 
-    private static final Logger logger = LogManager.getLogger(KeyRotationExample.class);
+    private static final Logger logger = LoggerFactory.getLogger(KeyRotationExample.class);
 
     public static void main(String[] args) throws Exception {
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());

--- a/jlibra-examples/src/main/java/dev/jlibra/example/MintExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/MintExample.java
@@ -2,8 +2,8 @@ package dev.jlibra.example;
 
 import static java.lang.String.format;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import kong.unirest.HttpResponse;
 import kong.unirest.Unirest;
@@ -22,10 +22,10 @@ import kong.unirest.Unirest;
  */
 public class MintExample {
 
-    private static final Logger logger = LogManager.getLogger(MintExample.class);
+    private static final Logger logger = LoggerFactory.getLogger(MintExample.class);
 
     public static void main(String[] args) {
-        String authenticationKey = "c0c19d6b1d48371ea28f0cdc5f74bba7b3f7e8e38f8c8393f281a2f0792a2849";
+        String authenticationKey = "57cc5b453426e3d8e212c7d25e128014ee25121cec7f67d0eb8b7ecbff27e742";
         long amountInMicroLibras = 10L * 1_000_000L;
 
         HttpResponse<String> response = Unirest.post("http://faucet.testnet.libra.org")
@@ -35,8 +35,9 @@ public class MintExample {
 
         if (response.getStatus() != 200) {
             throw new IllegalStateException(
-                    format("Error in minting %d Libra for authentication key %s", amountInMicroLibras,
-                            authenticationKey));
+                    format("Error in minting %d Libra for authentication key %s. Response: %d, message: %s",
+                            amountInMicroLibras,
+                            authenticationKey, response.getStatus(), response.getStatusText()));
 
         }
         logger.info(response.getBody());

--- a/jlibra-examples/src/main/java/dev/jlibra/example/TransferExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/TransferExample.java
@@ -6,8 +6,8 @@ import java.security.Security;
 import java.time.Instant;
 import java.util.Arrays;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.jlibra.AccountAddress;
 import dev.jlibra.AuthenticationKey;
@@ -29,7 +29,7 @@ import dev.jlibra.serialization.ByteArray;
 
 public class TransferExample {
 
-    private static final Logger logger = LogManager.getLogger(TransferExample.class);
+    private static final Logger logger = LoggerFactory.getLogger(TransferExample.class);
 
     public static void main(String[] args) throws Exception {
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());

--- a/jlibra-examples/src/main/java/dev/jlibra/example/TransferMultisigExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/TransferMultisigExample.java
@@ -5,8 +5,8 @@ import java.security.Security;
 import java.time.Instant;
 import java.util.Arrays;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import dev.jlibra.AccountAddress;
 import dev.jlibra.AuthenticationKey;
@@ -29,7 +29,7 @@ import dev.jlibra.serialization.ByteArray;
 
 public class TransferMultisigExample {
 
-    private static final Logger logger = LogManager.getLogger(TransferMultisigExample.class);
+    private static final Logger logger = LoggerFactory.getLogger(TransferMultisigExample.class);
 
     public static void main(String[] args) throws Exception {
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());

--- a/jlibra-examples/src/main/java/dev/jlibra/poller/Wait.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/poller/Wait.java
@@ -2,14 +2,14 @@ package dev.jlibra.poller;
 
 import java.time.Duration;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 
 public class Wait {
-    private static final Logger logger = LogManager.getLogger(Wait.class);
+    private static final Logger logger = LoggerFactory.getLogger(Wait.class);
 
     public static void until(WaitCondition waitCondition) {
         RetryPolicy<Boolean> retryPolicy = new RetryPolicy<Boolean>()

--- a/jlibra-examples/src/main/resources/log4j2.properties
+++ b/jlibra-examples/src/main/resources/log4j2.properties
@@ -4,7 +4,11 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS}| %m%n
 appender.console.filter.threshold.type = ThresholdFilter
-appender.console.filter.threshold.level = info
+appender.console.filter.threshold.level = debug
 
-rootLogger.level = debug
+logger.jlibra.name = dev.jlibra
+logger.jlibra.level = debug
+
+rootLogger.level = info
+
 rootLogger.appenderRef.stdout.ref = STDOUT

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>8</maven.compiler.source>
     <maven.compiler.target>8</maven.compiler.target>
+    <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>2.13.0</log4j.version>
   </properties>
 
@@ -74,13 +75,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${log4j.version}</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>log4j-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
+        <artifactId>log4j-slf4j-impl</artifactId>
         <version>${log4j.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
- slf4j added to enable logging from core module. examples-module was also changed to use slf4j api
- Added a workaround for the issue #99 with the simple-json-rpc library. It will remove the attribute from the response which causes the issue.