### PR TITLE
Testnet 20200527

### DIFF
--- a/jlibra-core/src/main/java/dev/jlibra/client/LibraClient.java
+++ b/jlibra-core/src/main/java/dev/jlibra/client/LibraClient.java
@@ -13,6 +13,7 @@ import dev.jlibra.AccountAddress;
 import dev.jlibra.LibraRuntimeException;
 import dev.jlibra.client.views.Account;
 import dev.jlibra.client.views.BlockMetadata;
+import dev.jlibra.client.views.CurrencyInfo;
 import dev.jlibra.client.views.Event;
 import dev.jlibra.client.views.StateProof;
 import dev.jlibra.client.views.Transaction;
@@ -94,6 +95,16 @@ public class LibraClient {
             throw new LibraServerErrorException(e.getErrorMessage().getCode(), e.getErrorMessage().getMessage());
         } catch (Exception e) {
             throw new LibraRuntimeException("getStateProof failed", e);
+        }
+    }
+
+    public List<CurrencyInfo> currenciesInfo() {
+        try {
+            return libraJsonRpcClient.currenciesInfo();
+        } catch (JsonRpcException e) {
+            throw new LibraServerErrorException(e.getErrorMessage().getCode(), e.getErrorMessage().getMessage());
+        } catch (Exception e) {
+            throw new LibraRuntimeException("currenciesInfo failed", e);
         }
     }
 

--- a/jlibra-core/src/main/java/dev/jlibra/client/LibraJsonRpcClient.java
+++ b/jlibra-core/src/main/java/dev/jlibra/client/LibraJsonRpcClient.java
@@ -13,6 +13,7 @@ import com.github.arteam.simplejsonrpc.core.annotation.JsonRpcService;
 
 import dev.jlibra.client.views.Account;
 import dev.jlibra.client.views.BlockMetadata;
+import dev.jlibra.client.views.CurrencyInfo;
 import dev.jlibra.client.views.Event;
 import dev.jlibra.client.views.StateProof;
 import dev.jlibra.client.views.Transaction;
@@ -45,7 +46,9 @@ public interface LibraJsonRpcClient {
     @JsonRpcMethod("get_state_proof")
     StateProof getStateProof(@JsonRpcParam("know_version") long knownVersion);
 
+    @JsonRpcMethod("currencies_info")
+    List<CurrencyInfo> currenciesInfo();
+
     @JsonRpcMethod("submit")
     void submit(@JsonRpcParam("payload") String payload);
-
 }

--- a/jlibra-core/src/main/java/dev/jlibra/client/views/CurrencyInfo.java
+++ b/jlibra-core/src/main/java/dev/jlibra/client/views/CurrencyInfo.java
@@ -1,0 +1,20 @@
+package dev.jlibra.client.views;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableCurrencyInfo.class)
+public interface CurrencyInfo {
+
+    @JsonProperty("code")
+    String code();
+
+    @JsonProperty("fractional_part")
+    Long fractionalPart();
+
+    @JsonProperty("scaling_factor")
+    Long scalingFactor();
+}

--- a/jlibra-core/src/main/java/dev/jlibra/faucet/Faucet.java
+++ b/jlibra-core/src/main/java/dev/jlibra/faucet/Faucet.java
@@ -27,11 +27,12 @@ public class Faucet {
         this.url = url;
     }
 
-    public void mint(AuthenticationKey authenticationKey, long amountInMicroLibras) {
+    public void mint(AuthenticationKey authenticationKey, long amountInMicroLibras, String currencyCode) {
         try {
             URIBuilder builder = new URIBuilder(url)
                     .setParameter("amount", Long.toString(amountInMicroLibras))
-                    .setParameter("auth_key", authenticationKey.toString());
+                    .setParameter("auth_key", authenticationKey.toString())
+                    .setParameter("currency_code", currencyCode);
             HttpPost httpPost = new HttpPost(builder.build().toString());
             httpPost.addHeader(new BasicHeader(USER_AGENT, "JLibra"));
             httpPost.setEntity(new StringEntity(""));

--- a/jlibra-core/src/main/java/dev/jlibra/transaction/Signature.java
+++ b/jlibra-core/src/main/java/dev/jlibra/transaction/Signature.java
@@ -30,7 +30,7 @@ public interface Signature {
             java.security.Signature sgr = java.security.Signature.getInstance("Ed25519", "BC");
             sgr.initSign(privateKey);
             sgr.update(Hash.ofInput(transactionBytes)
-                    .hash(ByteArray.from("libra_types::transaction::RawTransaction@@$$LIBRA$$@@".getBytes()))
+                    .hash(ByteArray.from("LIBRA::RawTransaction".getBytes()))
                     .toArray());
             signature = sgr.sign();
         } catch (Exception e) {

--- a/jlibra-examples/src/main/java/dev/jlibra/example/KeyRotationExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/KeyRotationExample.java
@@ -58,7 +58,7 @@ public class KeyRotationExample {
         logger.info("Account address: {}", addressOriginal.toString());
         logger.info("Authentication key: {}", authenticationKeyOriginal.toString());
 
-        faucet.mint(authenticationKeyOriginal, 10L * 1_000_000L);
+        faucet.mint(authenticationKeyOriginal, 10L * 1_000_000L, "LBR");
 
         Wait.until(accountExists(addressOriginal, client));
 

--- a/jlibra-examples/src/main/java/dev/jlibra/example/MintExample.java
+++ b/jlibra-examples/src/main/java/dev/jlibra/example/MintExample.java
@@ -30,7 +30,7 @@ public class MintExample {
                 .fromHexString("83114168d1c4912ddfac857421cdcfa54fa2be7ad55936c5702e8b7e3fdedb05");
 
         Faucet faucet = Faucet.builder().build();
-        faucet.mint(authenticationKey, 10L * 1_000_000L);
+        faucet.mint(authenticationKey, 10L * 1_000_000L, "LBR");
 
         LibraClient client = LibraClient.builder()
                 .withUrl("http://client.testnet.libra.org/")

--- a/jlibra-integration-tests/src/test/java/dev/jlibra/integrationtest/MultisigTransactionTest.java
+++ b/jlibra-integration-tests/src/test/java/dev/jlibra/integrationtest/MultisigTransactionTest.java
@@ -69,7 +69,7 @@ public class MultisigTransactionTest {
 
         AuthenticationKey authenticationKey = AuthenticationKey.fromMultiSignaturePublicKey(multiPubKey);
         AccountAddress accountAddress = AccountAddress.fromAuthenticationKey(authenticationKey);
-        faucet.mint(authenticationKey, 10 * 1_000_000);
+        faucet.mint(authenticationKey, 10 * 1_000_000, "LBR");
         Wait.until(accountExists(accountAddress, client));
 
         // target account


### PR DESCRIPTION
- Faucet needs a currency code parameter now
- Supported currencies can be retrieved from currency info endpoint in the json rpc api
- The signing changed and the salt had to be changed

fixes #112 