### PR TITLE
Add new properties to move abort response

### DIFF
--- a/jlibra-core/src/main/java/dev/jlibra/client/views/transaction/vmstatus/MoveAbortExplanation.java
+++ b/jlibra-core/src/main/java/dev/jlibra/client/views/transaction/vmstatus/MoveAbortExplanation.java
@@ -1,0 +1,23 @@
+package dev.jlibra.client.views.transaction.vmstatus;
+
+import org.immutables.value.Value;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableMoveAbortExplanation.class)
+public interface MoveAbortExplanation {
+
+    @JsonProperty("category")
+    String category();
+
+    @JsonProperty("category_description")
+    String categoryDescription();
+
+    @JsonProperty("reason")
+    String reason();
+
+    @JsonProperty("reason_description")
+    String reasonDescription();
+}

--- a/jlibra-core/src/main/java/dev/jlibra/client/views/transaction/vmstatus/VmStatusMoveAbort.java
+++ b/jlibra-core/src/main/java/dev/jlibra/client/views/transaction/vmstatus/VmStatusMoveAbort.java
@@ -15,4 +15,7 @@ public interface VmStatusMoveAbort extends VmStatus {
     @JsonProperty("abort_code")
     Integer abortCode();
 
+    @JsonProperty("explanation")
+    MoveAbortExplanation explanation();
+
 }


### PR DESCRIPTION
- In case the transaction fails due to 'move abort' (for example when the target account does not exist) there are some new properties in the response that needed to be added to the response classes.